### PR TITLE
support getting best solution when optimal solution has not been reached

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -678,7 +678,7 @@ mod tests {
         assert_eq!(status, Status::Unbounded);
 
         let sol = solved_model.get_best_sol();
-        assert!(sol.is_none());
+        assert!(sol.is_some());
     }
 
     #[test]


### PR DESCRIPTION
See #41. I had encountered it when trying to configure a time bound with good_lp. This has been successfully returning returning a satisfactory, not optimal, solution.