### PR TITLE
Added `set_obj_integral` Method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 ### Added
+ - Added method `set_obj_integral` to allow specifying that the objective value is always integral.
 ### Fixed
 ### Changed
 ### Removed

--- a/src/model.rs
+++ b/src/model.rs
@@ -1075,6 +1075,24 @@ mod tests {
     }
 
     #[test]
+    fn set_obj_integral() {
+        let model = Model::new()
+            .hide_output()
+            .set_obj_integral()
+            .unwrap()
+            .include_default_plugins()
+            .read_prob("data/test/simple.lp")
+            .unwrap()
+            .solve();
+        let status = model.status();
+        assert_eq!(status, Status::Optimal);
+
+        //test objective value
+        let obj_value = model.obj_val();
+        assert_eq!(obj_value, 200.);
+    }
+
+    #[test]
     fn set_time_limit() {
         let model = Model::new()
             .hide_output()

--- a/src/model.rs
+++ b/src/model.rs
@@ -208,9 +208,11 @@ impl Model<ProblemCreated> {
     }
     
     /// Informs the SCIP instance that the objective value is always integral and returns the same `Model` instance.
-    pub fn set_obj_integral(mut self) -> Result<Self, Retcode> {
-        self.scip.set_obj_integral()?;
-        Ok(self)
+    pub fn set_obj_integral(mut self) -> Self {
+        self.scip
+            .set_obj_integral()
+            .expect("Failed to set the objective value as integral");
+        self
     }
 
     /// Adds a new variable to the model with the given lower bound, upper bound, objective coefficient, name, and type.
@@ -1082,7 +1084,6 @@ mod tests {
             .read_prob("data/test/simple.lp")
             .unwrap()
             .set_obj_integral()
-            .unwrap()
             .solve();
         let status = model.status();
         assert_eq!(status, Status::Optimal);

--- a/src/model.rs
+++ b/src/model.rs
@@ -102,12 +102,6 @@ impl Model<Unsolved> {
         Ok(self)
     }
 
-    /// Informs the SCIP instance that the objective value is always integral and returns the same `Model` instance.
-    pub fn set_obj_integral(mut self) -> Result<Self, Retcode> {
-        self.scip.set_obj_integral()?;
-        Ok(self)
-    }
-
     /// Sets the presolving parameter of the SCIP instance and returns the same `Model` instance.
     pub fn set_presolving(mut self, presolving: ParamSetting) -> Self {
         self.scip
@@ -211,6 +205,12 @@ impl Model<ProblemCreated> {
         self.scip
             .set_cons_modifiable(cons, modifiable)
             .expect("Failed to set constraint modifiable");
+    }
+    
+    /// Informs the SCIP instance that the objective value is always integral and returns the same `Model` instance.
+    pub fn set_obj_integral(mut self) -> Result<Self, Retcode> {
+        self.scip.set_obj_integral()?;
+        Ok(self)
     }
 
     /// Adds a new variable to the model with the given lower bound, upper bound, objective coefficient, name, and type.
@@ -1078,10 +1078,10 @@ mod tests {
     fn set_obj_integral() {
         let model = Model::new()
             .hide_output()
-            .set_obj_integral()
-            .unwrap()
             .include_default_plugins()
             .read_prob("data/test/simple.lp")
+            .unwrap()
+            .set_obj_integral()
             .unwrap()
             .solve();
         let status = model.status();

--- a/src/model.rs
+++ b/src/model.rs
@@ -102,6 +102,12 @@ impl Model<Unsolved> {
         Ok(self)
     }
 
+    /// Informs the SCIP instance that the objective value is always integral and returns the same `Model` instance.
+    pub fn set_obj_integral(mut self) -> Result<Self, Retcode> {
+        self.scip.set_obj_integral()?;
+        Ok(self)
+    }
+
     /// Sets the presolving parameter of the SCIP instance and returns the same `Model` instance.
     pub fn set_presolving(mut self, presolving: ParamSetting) -> Self {
         self.scip

--- a/src/scip.rs
+++ b/src/scip.rs
@@ -97,6 +97,11 @@ impl ScipPtr {
         Ok(())
     }
 
+    pub(crate) fn set_obj_integral(&mut self) -> Result<(), Retcode> {
+        scip_call!(ffi::SCIPsetObjIntegral(self.raw));
+        Ok(())
+    }
+
     pub(crate) fn n_vars(&self) -> usize {
         unsafe { ffi::SCIPgetNVars(self.raw) as usize }
     }


### PR DESCRIPTION
See Issue https://github.com/scipopt/russcip/issues/95

`cargo build` runs through, as well as `cargo fmt` (at least for my code).
I am unable to run `cargo test` at the moment, it currently says it cannot find `libscip.8.0.dylib` - seems unrelated to my code.

---

Changelog:
 - Added method [`set_obj_integral` in `scip.rs`](https://github.com/scipopt/russcip/pull/101/files#diff-91de7e02a70cfde327e83c028b40a7e6f486647d520450ad17ef538d9247b6c1R100) which calls `SCIPsetObjIntegral`
 - Added method [`set_obj_integral` to `Model<ProblemCreated>`](https://github.com/scipopt/russcip/pull/101/files#diff-6bd13171e8498a8adc17d13cef1f1b59f5fbd24ae4c72aeb4ce5f9b2b4703220R209) to allow specifying that the objective value is always integral
 - Added a [very simple test](https://github.com/scipopt/russcip/pull/101/files#diff-6bd13171e8498a8adc17d13cef1f1b59f5fbd24ae4c72aeb4ce5f9b2b4703220R1079) which simply verifies that the method does not raise any error