### PR TITLE
Fix the Windows MSVC build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## untracked
 ### Added
 ### Fixed
+ - Fixed Windows MSVC build.
 ### Changed
 ### Removed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["data/test/*"]
 raw = []
 
 [dependencies]
-scip-sys =  "0.1.4"
+scip-sys =  "0.1.5"
 doc-comment = "0.3.3"
 
 [dev-dependencies]

--- a/data/ignored/.gitignore
+++ b/data/ignored/.gitignore
@@ -1,0 +1,3 @@
+# ignore everything except .gitignore, ensuring this directory actually exists
+*
+!.gitignore

--- a/src/branchrule.rs
+++ b/src/branchrule.rs
@@ -2,7 +2,6 @@ use crate::ffi;
 use crate::variable::Variable;
 use std::rc::Rc;
 use scip_sys::SCIP_Result;
-use crate::model::WithSolvingStats;
 
 /// A trait for defining custom branching rules.
 pub trait BranchRule {
@@ -57,7 +56,7 @@ pub struct BranchingCandidate {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::model::{ModelWithProblem, ProblemCreated};
+    use crate::model::ModelWithProblem;
     use crate::Solving;
     use crate::{model::Model, status::Status};
 

--- a/src/branchrule.rs
+++ b/src/branchrule.rs
@@ -1,6 +1,7 @@
 use crate::ffi;
 use crate::variable::Variable;
 use std::rc::Rc;
+use scip_sys::SCIP_Result;
 use crate::model::WithSolvingStats;
 
 /// A trait for defining custom branching rules.
@@ -28,7 +29,7 @@ pub enum BranchingResult {
     ConsAdded,
 }
 
-impl From<BranchingResult> for u32 {
+impl From<BranchingResult> for SCIP_Result {
     fn from(val: BranchingResult) -> Self {
         match val {
             BranchingResult::DidNotRun => ffi::SCIP_Result_SCIP_DIDNOTRUN,

--- a/src/heuristic.rs
+++ b/src/heuristic.rs
@@ -1,4 +1,5 @@
 use std::ops::{BitOr, BitOrAssign};
+use scip_sys::SCIP_Result;
 
 use crate::ffi;
 
@@ -87,7 +88,7 @@ impl From<u32> for HeurTiming {
     }
 }
 
-impl From<HeurResult> for u32 {
+impl From<HeurResult> for SCIP_Result {
     fn from(val: HeurResult) -> Self {
         match val {
             HeurResult::FoundSol => ffi::SCIP_Result_SCIP_FOUNDSOL,

--- a/src/model.rs
+++ b/src/model.rs
@@ -1510,9 +1510,10 @@ mod tests {
 
     #[test]
     fn set_str_param() {
+        let output_path = "data/ignored/test.vbc";
         let mut model = Model::new()
             .hide_output()
-            .set_str_param("visual/vbcfilename", "test.vbc")
+            .set_str_param("visual/vbcfilename", output_path)
             .unwrap()
             .include_default_plugins()
             .create_prob("test")
@@ -1527,8 +1528,11 @@ mod tests {
         assert_eq!(status, Status::Optimal);
         assert_eq!(solved_model.obj_val(), 3.);
 
-        assert!(Path::new("test.vbc").exists());
-        fs::remove_file("test.vbc").unwrap();
+        assert!(Path::new(output_path).exists());
+
+        // drop model so the file is closed and it can be removed
+        drop(solved_model);
+        fs::remove_file(output_path).unwrap();
     }
 
     #[test]

--- a/src/pricer.rs
+++ b/src/pricer.rs
@@ -1,3 +1,4 @@
+use scip_sys::SCIP_Result;
 use crate::ffi;
 
 /// A trait for SCIP pricers.
@@ -30,7 +31,7 @@ pub struct PricerResult {
     pub lower_bound: Option<f64>,
 }
 
-impl From<PricerResultState> for u32 {
+impl From<PricerResultState> for SCIP_Result {
     /// Converts a `PricerResultState` enum variant to an `SCIP_Result` value.
     fn from(val: PricerResultState) -> Self {
         match val {

--- a/src/pricer.rs
+++ b/src/pricer.rs
@@ -47,7 +47,7 @@ impl From<PricerResultState> for SCIP_Result {
 mod tests {
     use super::*;
     use crate::{
-        model::{Model, ModelWithProblem, ProblemCreated},
+        model::{Model, ModelWithProblem},
         status::Status,
         variable::VarType, Solving, ProblemOrSolving,
     };

--- a/src/status.rs
+++ b/src/status.rs
@@ -1,3 +1,4 @@
+use scip_sys::SCIP_Status;
 use crate::ffi;
 
 /// An enum representing the status of a SCIP optimization run.
@@ -37,9 +38,9 @@ pub enum Status {
     Terminate,
 }
 
-impl From<u32> for Status {
+impl From<SCIP_Status> for Status {
     /// Converts a u32 value to a `Status` enum variant.
-    fn from(val: u32) -> Self {
+    fn from(val: SCIP_Status) -> Self {
         match val {
             ffi::SCIP_Status_SCIP_STATUS_UNKNOWN => Status::Unknown,
             ffi::SCIP_Status_SCIP_STATUS_USERINTERRUPT => Status::UserInterrupt,

--- a/src/variable.rs
+++ b/src/variable.rs
@@ -1,5 +1,6 @@
 use crate::ffi;
 use core::panic;
+use scip_sys::SCIP_Status;
 
 /// A type alias for a variable ID.
 pub type VarId = usize;
@@ -114,8 +115,8 @@ pub enum VarStatus {
     NegatedVar,
 }
 
-impl From<u32> for VarStatus {
-    fn from(status: u32) -> Self {
+impl From<SCIP_Status> for VarStatus {
+    fn from(status: SCIP_Status) -> Self {
         match status {
             ffi::SCIP_Varstatus_SCIP_VARSTATUS_ORIGINAL => VarStatus::Original,
             ffi::SCIP_Varstatus_SCIP_VARSTATUS_LOOSE => VarStatus::Loose,


### PR DESCRIPTION
Fixes https://github.com/scipopt/russcip/issues/114, also has some other small improvements.

Depends on https://github.com/scipopt/scip-sys/pull/4 to actually fully build on windows, so maybe a version bump of the sys crate and a corresponding change in this `Cargo.toml` is necessary.