### PR TITLE
Update scip-sys

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -21,8 +21,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install dependencies (SCIPOptSuite)
         run: |
-          wget --quiet --no-check-certificate https://github.com/scipopt/scip/releases/download/$(echo "v${{env.version}}" | tr -d '.')/SCIPOptSuite-${{ env.version }}-Linux-ubuntu.deb
-          sudo apt-get update && sudo apt install -y ./SCIPOptSuite-${{ env.version }}-Linux-ubuntu.deb
+          wget --quiet --no-check-certificate https://github.com/scipopt/scip/releases/download/$(echo "v${{env.version}}" | tr -d '.')/SCIPOptSuite-${{ env.version }}-Linux-ubuntu20.deb
+          sudo apt-get update && sudo apt install -y ./SCIPOptSuite-${{ env.version }}-Linux-ubuntu20.deb
 
       - name: Install rust stable toolchain
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,7 +1,7 @@
 name: tests
 
 env:
-  version: 8.0.3
+  version: 9.0.0
   RUST_VERSION: 1.74.0
 
 on:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,17 @@
 # CHANGELOG
 
+# Unreleased
 ### Added
 ### Fixed
 ### Changed
 ### Remove
+
+## 0.3.1
+### Added
+### Fixed
+### Changed
+- Update scip-sys to 0.1.9 to use github hosted binaries of SCIP.
+### Removed
 
 ## 0.3.0
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["Mohammad Ghannam <mohammad.m.ghannam@gmail.com>"]
 description = "Rust interface for SCIP"
 license = "Apache-2.0"
 repository = "https://github.com/scipopt/russcip"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 exclude = ["data/test/*"]
 
@@ -13,7 +13,7 @@ raw = []
 bundled = ["scip-sys/bundled"]
 
 [dependencies]
-scip-sys =  "0.1.8"
+scip-sys =  "0.1.9"
 
 [dev-dependencies]
 rayon = "1.5.1"


### PR DESCRIPTION
Use the new version of scip-sys that use github hosted SCIP binaries.