### PR TITLE
Add lifetime to solution

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -536,13 +536,13 @@ impl_ModelWithProblem!(for Model<ProblemCreated>, Model<Solved>, Model<Solving>)
 /// A trait for optimization models with a problem created or solved.
 pub trait ProblemOrSolving {
     /// Creates a new solution initialized to zero.
-    fn create_sol(&mut self) -> Solution;
+    fn create_sol(&self) -> Solution;
 
     /// Adds a solution to the model
     ///
     /// # Returns
     /// A `Result` indicating whether the solution was added successfully.
-    fn add_sol(&self, sol: Solution) -> Result<(), SolError>;
+    fn add_sol(&self, sol: Solution<'_>) -> Result<(), SolError>;
 
     /// Adds a binary variable to the given set partitioning constraint.
     ///
@@ -724,7 +724,7 @@ macro_rules! impl_ProblemOrSolving {
         $(impl ProblemOrSolving for $t {
 
             /// Creates a new solution initialized to zero.
-            fn create_sol(&mut self) -> Solution {
+            fn create_sol(&self) -> Solution {
                 self.scip
                     .create_sol()
                     .expect("Failed to create solution in state ProblemCreated")

--- a/src/scip.rs
+++ b/src/scip.rs
@@ -180,12 +180,13 @@ impl ScipPtr {
         unsafe { ffi::SCIPgetNSols(self.raw) as usize }
     }
 
-    pub(crate) fn best_sol(&self) -> Solution {
+    pub(crate) fn best_sol(&self) -> Solution<'_> {
         let sol = unsafe { ffi::SCIPgetBestSol(self.raw) };
 
         Solution {
             scip_ptr: self.raw,
             raw: sol,
+            pd: Default::default(),
         }
     }
 
@@ -491,6 +492,7 @@ impl ScipPtr {
         Ok(Solution {
             scip_ptr: self.raw,
             raw: sol,
+            pd: Default::default(),
         })
     }
 

--- a/src/solution.rs
+++ b/src/solution.rs
@@ -6,12 +6,13 @@ use crate::{ffi, scip_call_panic};
 
 /// A wrapper for a SCIP solution.
 #[derive(PartialEq, Eq)]
-pub struct Solution {
+pub struct Solution<'a> {
     pub(crate) scip_ptr: *mut ffi::SCIP,
     pub(crate) raw: *mut ffi::SCIP_SOL,
+    pub(crate) pd: std::marker::PhantomData<fn() -> &'a ()>, //covariant
 }
 
-impl Solution {
+impl Solution<'_> {
     /// Returns the objective value of the solution.
     pub fn obj_val(&self) -> f64 {
         unsafe { ffi::SCIPgetSolOrigObj(self.scip_ptr, self.raw) }
@@ -28,7 +29,7 @@ impl Solution {
     }
 }
 
-impl fmt::Debug for Solution {
+impl fmt::Debug for Solution<'_> {
     /// Formats the solution for debugging purposes.
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let obj_val = self.obj_val();


### PR DESCRIPTION
This is my proposed solution to #138.
Had to change `create_sol` to admit `&self` instead of `&mut self` (because otherwise `model` cannot be borrowed). With this changes should make it not possible to perform use after free (with `solution`, [`clone_for_plugin`](https://github.com/scipopt/russcip/blob/b44bc337fb6b82a71912b5d99a99d6d992be341f/src/model.rs#L134) seems to also allow use after free).
The tests pass otherwise.

Do of this what you want.