### PR TITLE
Hold a SCIP pointer to prevent freeing the model while the constraint is still in use

### DIFF
--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -1,6 +1,6 @@
-use std::rc::Rc;
 use crate::ffi;
 use crate::scip::ScipPtr;
+use std::rc::Rc;
 
 /// A constraint in an optimization problem.
 #[derive(Debug)]
@@ -28,8 +28,6 @@ impl Constraint {
     }
 }
 
-
-
 #[cfg(test)]
 mod tests {
     use crate::prelude::*;
@@ -42,7 +40,6 @@ mod tests {
             .include_default_plugins()
             .create_prob("test")
             .set_obj_sense(ObjSense::Maximize);
-
 
         let x1 = model.add_var(0., f64::INFINITY, 3., "x1", VarType::Integer);
         let cons = model.add_cons(vec![x1], &[1.], 4., 4., "cons");

--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -1,10 +1,15 @@
+use std::rc::Rc;
 use crate::ffi;
+use crate::scip::ScipPtr;
 
 /// A constraint in an optimization problem.
 #[derive(Debug)]
+#[allow(dead_code)]
 pub struct Constraint {
     /// A pointer to the underlying `SCIP_CONS` C struct.
     pub(crate) raw: *mut ffi::SCIP_CONS,
+    /// A reference to the SCIP instance that owns this constraint (to prevent freeing the model while the constraint is live).
+    pub(crate) scip: Rc<ScipPtr>,
 }
 
 impl Constraint {
@@ -20,5 +25,29 @@ impl Constraint {
             let name = ffi::SCIPconsGetName(self.raw);
             String::from(std::ffi::CStr::from_ptr(name).to_str().unwrap())
         }
+    }
+}
+
+
+
+#[cfg(test)]
+mod tests {
+    use crate::prelude::*;
+
+    #[test]
+    fn test_constraint_mem_safety() {
+        // Create model
+        let mut model = Model::new()
+            .hide_output()
+            .include_default_plugins()
+            .create_prob("test")
+            .set_obj_sense(ObjSense::Maximize);
+
+
+        let x1 = model.add_var(0., f64::INFINITY, 3., "x1", VarType::Integer);
+        let cons = model.add_cons(vec![x1], &[1.], 4., 4., "cons");
+        drop(model);
+
+        assert_eq!(cons.name(), "cons");
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -106,11 +106,14 @@ impl Model<PluginsIncluded> {
         let scip = self.scip.clone();
         scip.read_prob(filename)?;
         let vars = Rc::new(RefCell::new(self.scip.vars()));
-        let conss = Rc::new(RefCell::new(self.scip.conss()));
+        let conss = Rc::new(RefCell::new(self.scip.conss().iter().map(|c| Rc::new( Constraint {
+            raw: *c,
+            scip: self.scip.clone(),
+        })).collect()));
         let new_model = Model {
             scip: self.scip,
-            state: ProblemCreated { vars, conss },
-        };
+            state: ProblemCreated { vars, conss}
+            };
         Ok(new_model)
     }
 }
@@ -835,7 +838,12 @@ macro_rules! impl_ProblemOrSolving {
                         name,
                     )
                     .expect("Failed to create constraint in state ProblemCreated");
-                let cons = Rc::new(cons);
+                let cons = Rc::new(
+                    Constraint {
+                        raw: cons,
+                        scip: self.scip.clone(),
+                    }
+                );
                 self.state.conss.borrow_mut().push(cons.clone());
                 cons
             }
@@ -872,7 +880,10 @@ macro_rules! impl_ProblemOrSolving {
                     .scip
                     .create_cons(vars, coefs, lhs, rhs, name)
                     .expect("Failed to create constraint in state ProblemCreated");
-                let cons = Rc::new(cons);
+                let cons = Rc::new( Constraint {
+                    raw: cons,
+                    scip: self.scip.clone(),
+                });
                 self.state.conss.borrow_mut().push(cons.clone());
                 cons
             }
@@ -897,7 +908,10 @@ macro_rules! impl_ProblemOrSolving {
                     .scip
                     .create_cons_set_part(vars, name)
                     .expect("Failed to add constraint set partition in state ProblemCreated");
-                let cons = Rc::new(cons);
+                let cons = Rc::new( Constraint {
+                    raw: cons,
+                    scip: self.scip.clone(),
+                });
                 self.state.conss.borrow_mut().push(cons.clone());
                 cons
             }
@@ -922,7 +936,10 @@ macro_rules! impl_ProblemOrSolving {
                     .scip
                     .create_cons_set_cover(vars, name)
                     .expect("Failed to add constraint set cover in state ProblemCreated");
-                let cons = Rc::new(cons);
+                let cons = Rc::new( Constraint {
+                    raw: cons,
+                    scip: self.scip.clone(),
+                });
                 self.state.conss.borrow_mut().push(cons.clone());
                 cons
             }
@@ -947,7 +964,10 @@ macro_rules! impl_ProblemOrSolving {
                     .scip
                     .create_cons_set_pack(vars, name)
                     .expect("Failed to add constraint set packing in state ProblemCreated");
-                let cons = Rc::new(cons);
+                let cons = Rc::new( Constraint {
+                    raw: cons,
+                    scip: self.scip.clone(),
+                });
                 self.state.conss.borrow_mut().push(cons.clone());
                 cons
             }
@@ -972,7 +992,10 @@ macro_rules! impl_ProblemOrSolving {
                     .scip
                     .create_cons_cardinality(vars, cardinality, name)
                     .expect("Failed to add cardinality constraint");
-                let cons = Rc::new(cons);
+                let cons = Rc::new( Constraint {
+                    raw: cons,
+                    scip: self.scip.clone(),
+                });
                 self.state.conss.borrow_mut().push(cons.clone());
                 cons
             }
@@ -1008,7 +1031,10 @@ macro_rules! impl_ProblemOrSolving {
                     .scip
                     .create_cons_indicator(bin_var, vars, coefs, rhs, name)
                     .expect("Failed to create constraint in state ProblemCreated");
-                let cons = Rc::new(cons);
+                let cons = Rc::new( Constraint {
+                    raw: cons,
+                    scip: self.scip.clone(),
+                });
                 self.state.conss.borrow_mut().push(cons.clone());
                 cons
             }

--- a/src/model.rs
+++ b/src/model.rs
@@ -106,14 +106,22 @@ impl Model<PluginsIncluded> {
         let scip = self.scip.clone();
         scip.read_prob(filename)?;
         let vars = Rc::new(RefCell::new(self.scip.vars()));
-        let conss = Rc::new(RefCell::new(self.scip.conss().iter().map(|c| Rc::new( Constraint {
-            raw: *c,
-            scip: self.scip.clone(),
-        })).collect()));
+        let conss = Rc::new(RefCell::new(
+            self.scip
+                .conss()
+                .iter()
+                .map(|c| {
+                    Rc::new(Constraint {
+                        raw: *c,
+                        scip: self.scip.clone(),
+                    })
+                })
+                .collect(),
+        ));
         let new_model = Model {
             scip: self.scip,
-            state: ProblemCreated { vars, conss}
-            };
+            state: ProblemCreated { vars, conss },
+        };
         Ok(new_model)
     }
 }


### PR DESCRIPTION
This is the second step for #151 that fixes use after free errors when using constraints after the model is freed. 