### PR TITLE
Use older runner for conda test

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -42,7 +42,7 @@ jobs:
           fail_ci_if_error: false
 
   linux-conda-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: conda-incubator/setup-miniconda@v2


### PR DESCRIPTION
Due to issues with leak sanitizer with ubuntu 24.04 https://github.com/rust-lang/rust/issues/111073