### PR TITLE
Remove use of Rc for `Variable` and `Constraint` & Add parameter getters

### DIFF
--- a/examples/create_and_solve.rs
+++ b/examples/create_and_solve.rs
@@ -14,14 +14,14 @@ fn main() {
 
     // Add constraints
     model.add_cons(
-        vec![x1.clone(), x2.clone()],
+        vec![&x1, &x2],
         &[2., 1.],
         -f64::INFINITY,
         100.,
         "c1",
     );
     model.add_cons(
-        vec![x1.clone(), x2.clone()],
+        vec![&x1, &x2],
         &[1., 2.],
         -f64::INFINITY,
         80.,
@@ -40,6 +40,6 @@ fn main() {
     let vars = solved_model.vars();
 
     for var in vars {
-        println!("{} = {}", &var.name(), sol.val(var));
+        println!("{} = {}", var.name(), sol.val(&var));
     }
 }

--- a/examples/create_and_solve.rs
+++ b/examples/create_and_solve.rs
@@ -13,20 +13,8 @@ fn main() {
     let x2 = model.add_var(0., f64::INFINITY, 4., "x2", VarType::Integer);
 
     // Add constraints
-    model.add_cons(
-        vec![&x1, &x2],
-        &[2., 1.],
-        -f64::INFINITY,
-        100.,
-        "c1",
-    );
-    model.add_cons(
-        vec![&x1, &x2],
-        &[1., 2.],
-        -f64::INFINITY,
-        80.,
-        "c2",
-    );
+    model.add_cons(vec![&x1, &x2], &[2., 1.], -f64::INFINITY, 100., "c1");
+    model.add_cons(vec![&x1, &x2], &[1., 2.], -f64::INFINITY, 80., "c2");
 
     let solved_model = model.solve();
 

--- a/src/col.rs
+++ b/src/col.rs
@@ -239,7 +239,7 @@ mod tests {
         let mut model = minimal_model();
         let x = model.add_var(0.0, 1.0, 1.0, "x", VarType::Binary);
 
-        let cons = model.add_cons(vec![x], &[1.0], 1.0, 1.0, "cons1");
+        let cons = model.add_cons(vec![&x], &[1.0], 1.0, 1.0, "cons1");
         model.set_cons_modifiable(cons, true);
 
         let eventhdlr = Box::new(ColTesterEventHandler);

--- a/src/col.rs
+++ b/src/col.rs
@@ -240,7 +240,7 @@ mod tests {
         let x = model.add_var(0.0, 1.0, 1.0, "x", VarType::Binary);
 
         let cons = model.add_cons(vec![&x], &[1.0], 1.0, 1.0, "cons1");
-        model.set_cons_modifiable(cons, true);
+        model.set_cons_modifiable(&cons, true);
 
         let eventhdlr = Box::new(ColTesterEventHandler);
         model = model.include_eventhdlr("ColTesterEventHandler", "", eventhdlr);

--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -3,7 +3,7 @@ use crate::{ffi, Row};
 use std::rc::Rc;
 
 /// A constraint in an optimization problem.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[allow(dead_code)]
 pub struct Constraint {
     /// A pointer to the underlying `SCIP_CONS` C struct.
@@ -54,7 +54,7 @@ mod tests {
             .set_obj_sense(ObjSense::Maximize);
 
         let x1 = model.add_var(0., f64::INFINITY, 3., "x1", VarType::Integer);
-        let cons = model.add_cons(vec![x1], &[1.], 4., 4., "cons");
+        let cons = model.add_cons(vec![&x1], &[1.], 4., 4., "cons");
         drop(model);
 
         assert_eq!(cons.name(), "cons");

--- a/src/heuristic.rs
+++ b/src/heuristic.rs
@@ -272,7 +272,7 @@ mod tests {
         ) -> HeurResult {
             let sol = model.create_sol();
             for var in model.vars() {
-                sol.set_val(var, 1.0);
+                sol.set_val(&var, 1.0);
             }
             assert_eq!(sol.obj_val(), 7.0);
             assert_eq!(model.add_sol(sol), Ok(()));

--- a/src/model.rs
+++ b/src/model.rs
@@ -1492,13 +1492,7 @@ mod tests {
 
         let x1 = model.add_var(0., f64::INFINITY, 3., "x1", VarType::Integer);
         let x2 = model.add_var(0., f64::INFINITY, 4., "x2", VarType::Integer);
-        model.add_cons(
-            vec![&x1, &x2],
-            &[2., 1.],
-            -f64::INFINITY,
-            100.,
-            "c1",
-        );
+        model.add_cons(vec![&x1, &x2], &[2., 1.], -f64::INFINITY, 100., "c1");
         model.add_cons(vec![&x1, &x2], &[1., 2.], -f64::INFINITY, 80., "c2");
 
         model
@@ -1578,20 +1572,8 @@ mod tests {
 
         let x1 = model.add_var(0., f64::INFINITY, 3., "x1", VarType::Integer);
         let x2 = model.add_var(0., f64::INFINITY, 4., "x2", VarType::Integer);
-        model.add_cons(
-            vec![&x1, &x2],
-            &[2., 1.],
-            -f64::INFINITY,
-            100.,
-            "c1",
-        );
-        model.add_cons(
-            vec![&x1, &x2],
-            &[1., 2.],
-            -f64::INFINITY,
-            80.,
-            "c2",
-        );
+        model.add_cons(vec![&x1, &x2], &[2., 1.], -f64::INFINITY, 100., "c1");
+        model.add_cons(vec![&x1, &x2], &[1., 2.], -f64::INFINITY, 80., "c2");
 
         let scip_ptr = model.scip.raw;
         assert!(!scip_ptr.is_null());
@@ -1680,13 +1662,7 @@ mod tests {
         let b = model.add_var(0., 1., 0., "b", VarType::Binary);
 
         // Indicator constraint: `b == 1` implies `x1 - x2 <= -1`
-        model.add_cons_indicator(
-            &b,
-            vec![&x1, &x2],
-            &mut [1., -1.],
-            -1.,
-            "indicator",
-        );
+        model.add_cons_indicator(&b, vec![&x1, &x2], &mut [1., -1.], -1., "indicator");
 
         // Force `b` to be exactly 1 and later make sure that the constraint `x1 - x2 <= -1` is
         // indeed active

--- a/src/model.rs
+++ b/src/model.rs
@@ -1299,22 +1299,30 @@ impl<T> Model<T> {
 
     /// Returns the value of a SCIP boolean parameter.
     pub fn bool_param(&self, param: &str) -> bool {
-        self.scip.bool_param(param).expect("Failed to get boolean parameter")
+        self.scip
+            .bool_param(param)
+            .expect("Failed to get boolean parameter")
     }
 
     /// Returns the value of a SCIP integer parameter.
     pub fn int_param(&self, param: &str) -> i32 {
-        self.scip.int_param(param).expect("Failed to get integer parameter")
+        self.scip
+            .int_param(param)
+            .expect("Failed to get integer parameter")
     }
 
     /// Returns the value of a SCIP long integer parameter.
     pub fn longint_param(&self, param: &str) -> i64 {
-        self.scip.longint_param(param).expect("Failed to get long integer parameter")
+        self.scip
+            .longint_param(param)
+            .expect("Failed to get long integer parameter")
     }
 
     /// Returns the value of a SCIP real parameter.
     pub fn real_param(&self, param: &str) -> f64 {
-        self.scip.real_param(param).expect("Failed to get real parameter")
+        self.scip
+            .real_param(param)
+            .expect("Failed to get real parameter")
     }
 
     /// Sets the presolving parameter of the SCIP instance and returns the same `Model` instance.
@@ -1774,7 +1782,7 @@ mod tests {
             .hide_output()
             .set_str_param("visual/vbcfilename", output_path)
             .unwrap();
-        
+
         assert_eq!(model.str_param("visual/vbcfilename"), output_path);
     }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -1289,6 +1289,34 @@ impl<T> Model<T> {
         Ok(self)
     }
 
+    /// Returns the value of a SCIP string parameter.
+    pub fn str_param(&self, param: &str) -> String {
+        self.scip
+            .str_param(param)
+            .expect("Failed to get string parameter")
+            .to_string()
+    }
+
+    /// Returns the value of a SCIP boolean parameter.
+    pub fn bool_param(&self, param: &str) -> bool {
+        self.scip.bool_param(param).expect("Failed to get boolean parameter")
+    }
+
+    /// Returns the value of a SCIP integer parameter.
+    pub fn int_param(&self, param: &str) -> i32 {
+        self.scip.int_param(param).expect("Failed to get integer parameter")
+    }
+
+    /// Returns the value of a SCIP long integer parameter.
+    pub fn longint_param(&self, param: &str) -> i64 {
+        self.scip.longint_param(param).expect("Failed to get long integer parameter")
+    }
+
+    /// Returns the value of a SCIP real parameter.
+    pub fn real_param(&self, param: &str) -> f64 {
+        self.scip.real_param(param).expect("Failed to get real parameter")
+    }
+
     /// Sets the presolving parameter of the SCIP instance and returns the same `Model` instance.
     #[allow(unused_mut)]
     pub fn set_presolving(mut self, presolving: ParamSetting) -> Self {
@@ -1376,7 +1404,6 @@ mod tests {
     use crate::status::Status;
     use rayon::prelude::*;
     use std::fs;
-    use std::path::Path;
 
     use super::*;
 
@@ -1743,28 +1770,12 @@ mod tests {
     #[test]
     fn set_str_param() {
         let output_path = "data/ignored/test.vbc";
-        let mut model = Model::new()
+        let model = Model::new()
             .hide_output()
             .set_str_param("visual/vbcfilename", output_path)
-            .unwrap()
-            .include_default_plugins()
-            .create_prob("test")
-            .set_obj_sense(ObjSense::Minimize);
-
-        let x1 = model.add_var(0., 1., 3., "x1", VarType::Binary);
-        let x2 = model.add_var(0., 1., 4., "x2", VarType::Binary);
-        model.add_cons_set_part(vec![&x1, &x2], "c");
-
-        let solved_model = model.solve();
-        let status = solved_model.status();
-        assert_eq!(status, Status::Optimal);
-        assert_eq!(solved_model.obj_val(), 3.);
-
-        assert!(Path::new(output_path).exists());
-
-        // drop model so the file is closed and it can be removed
-        drop(solved_model);
-        fs::remove_file(output_path).unwrap();
+            .unwrap();
+        
+        assert_eq!(model.str_param("visual/vbcfilename"), output_path);
     }
 
     #[test]
@@ -1809,10 +1820,12 @@ mod tests {
 
     #[test]
     fn set_bool_param() {
-        Model::new()
+        let model = Model::new()
             .hide_output()
             .set_bool_param("display/allviols", true)
             .unwrap();
+
+        assert!(model.bool_param("display/allviols"));
     }
 
     #[test]
@@ -1830,13 +1843,9 @@ mod tests {
         let model = Model::new()
             .hide_output()
             .set_real_param("limits/time", 0.)
-            .unwrap()
-            .include_default_plugins()
-            .read_prob("data/test/simple.lp")
-            .unwrap()
-            .solve();
+            .unwrap();
 
-        assert_eq!(model.status(), Status::TimeLimit);
+        assert_eq!(model.real_param("limits/time"), 0.);
     }
 
     #[test]

--- a/src/pricer.rs
+++ b/src/pricer.rs
@@ -230,7 +230,7 @@ mod tests {
                 let var = model.add_priced_var(0.0, 1.0, 1.0, "x", VarType::Binary);
                 let conss = model.conss();
                 for cons in conss {
-                    model.add_cons_coef(cons, var.clone(), 1.0);
+                    model.add_cons_coef(cons, &var, 1.0);
                 }
                 let nvars_after = model.n_vars();
                 assert_eq!(nvars_before + 1, nvars_after);

--- a/src/pricer.rs
+++ b/src/pricer.rs
@@ -230,7 +230,7 @@ mod tests {
                 let var = model.add_priced_var(0.0, 1.0, 1.0, "x", VarType::Binary);
                 let conss = model.conss();
                 for cons in conss {
-                    model.add_cons_coef(cons, &var, 1.0);
+                    model.add_cons_coef(&cons, &var, 1.0);
                 }
                 let nvars_after = model.n_vars();
                 assert_eq!(nvars_before + 1, nvars_after);
@@ -252,7 +252,7 @@ mod tests {
 
         let conss = model.conss();
         for c in conss {
-            model.set_cons_modifiable(c, true);
+            model.set_cons_modifiable(&c, true);
         }
 
         let pricer = AddSameColumnPricer {

--- a/src/row.rs
+++ b/src/row.rs
@@ -285,7 +285,7 @@ mod tests {
         let x = model.add_var(0.0, 1.0, 1.0, "x", VarType::Binary);
 
         let cons = model.add_cons(vec![&x], &[1.0], 1.0, 1.0, "cons1");
-        model.set_cons_modifiable(cons, true);
+        model.set_cons_modifiable(&cons, true);
 
         let eventhdlr = Box::new(RowTesterEventHandler);
         model = model.include_eventhdlr("ColTesterEventHandler", "", eventhdlr);

--- a/src/row.rs
+++ b/src/row.rs
@@ -284,7 +284,7 @@ mod tests {
         let mut model = minimal_model();
         let x = model.add_var(0.0, 1.0, 1.0, "x", VarType::Binary);
 
-        let cons = model.add_cons(vec![x], &[1.0], 1.0, 1.0, "cons1");
+        let cons = model.add_cons(vec![&x], &[1.0], 1.0, 1.0, "cons1");
         model.set_cons_modifiable(cons, true);
 
         let eventhdlr = Box::new(RowTesterEventHandler);

--- a/src/scip.rs
+++ b/src/scip.rs
@@ -65,7 +65,7 @@ impl ScipPtr {
         scip_call! { ffi::SCIPsetBoolParam(self.raw, param.as_ptr(), if value { 1u32 } else { 0u32 }) };
         Ok(())
     }
-    
+
     pub(crate) fn bool_param(&self, param: &str) -> Result<bool, Retcode> {
         let param = CString::new(param).unwrap();
         let mut value = MaybeUninit::uninit();
@@ -79,7 +79,7 @@ impl ScipPtr {
         scip_call! { ffi::SCIPsetIntParam(self.raw, param.as_ptr(), value) };
         Ok(())
     }
-    
+
     pub(crate) fn int_param(&self, param: &str) -> Result<i32, Retcode> {
         let param = CString::new(param).unwrap();
         let mut value = MaybeUninit::uninit();
@@ -93,7 +93,7 @@ impl ScipPtr {
         scip_call! { ffi::SCIPsetLongintParam(self.raw, param.as_ptr(), value) };
         Ok(())
     }
-    
+
     pub(crate) fn longint_param(&self, param: &str) -> Result<i64, Retcode> {
         let param = CString::new(param).unwrap();
         let mut value = MaybeUninit::uninit();
@@ -107,7 +107,7 @@ impl ScipPtr {
         scip_call! { ffi::SCIPsetRealParam(self.raw, param.as_ptr(), value) };
         Ok(())
     }
-    
+
     pub(crate) fn real_param(&self, param: &str) -> Result<f64, Retcode> {
         let param = CString::new(param).unwrap();
         let mut value = MaybeUninit::uninit();

--- a/src/scip.rs
+++ b/src/scip.rs
@@ -295,7 +295,7 @@ impl ScipPtr {
 
     pub(crate) fn create_cons(
         &self,
-        vars: Vec<Rc<Variable>>,
+        vars: Vec<&Variable>,
         coefs: &[f64],
         lhs: f64,
         rhs: f64,
@@ -329,7 +329,7 @@ impl ScipPtr {
     /// Create set partitioning constraint
     pub(crate) fn create_cons_set_part(
         &self,
-        vars: Vec<Rc<Variable>>,
+        vars: Vec<&Variable>,
         name: &str,
     ) -> Result<*mut SCIP_Cons, Retcode> {
         let c_name = CString::new(name).unwrap();
@@ -352,7 +352,7 @@ impl ScipPtr {
     /// Create set cover constraint
     pub(crate) fn create_cons_set_cover(
         &self,
-        vars: Vec<Rc<Variable>>,
+        vars: Vec<&Variable>,
         name: &str,
     ) -> Result<*mut SCIP_Cons, Retcode> {
         let c_name = CString::new(name).unwrap();
@@ -374,10 +374,10 @@ impl ScipPtr {
 
     pub(crate) fn create_cons_quadratic(
         &self,
-        lin_vars: Vec<Rc<Variable>>,
+        lin_vars: Vec<&Variable>,
         lin_coefs: &mut [f64],
-        quad_vars_1: Vec<Rc<Variable>>,
-        quad_vars_2: Vec<Rc<Variable>>,
+        quad_vars_1: Vec<&Variable>,
+        quad_vars_2: Vec<&Variable>,
         quad_coefs: &mut [f64],
         lhs: f64,
         rhs: f64,
@@ -398,7 +398,7 @@ impl ScipPtr {
         let c_name = CString::new(name).unwrap();
         let mut scip_cons = MaybeUninit::uninit();
 
-        let get_ptrs = |vars: Vec<Rc<Variable>>| {
+        let get_ptrs = |vars: Vec<&Variable>| {
             vars.into_iter()
                 .map(|var_rc| var_rc.raw)
                 .collect::<Vec<_>>()
@@ -429,7 +429,7 @@ impl ScipPtr {
     /// Create set packing constraint
     pub(crate) fn create_cons_set_pack(
         &self,
-        vars: Vec<Rc<Variable>>,
+        vars: Vec<&Variable>,
         name: &str,
     ) -> Result<*mut SCIP_Cons, Retcode> {
         let c_name = CString::new(name).unwrap();
@@ -452,7 +452,7 @@ impl ScipPtr {
     /// Create cardinality constraint
     pub(crate) fn create_cons_cardinality(
         &self,
-        vars: Vec<Rc<Variable>>,
+        vars: Vec<&Variable>,
         cardinality: usize,
         name: &str,
     ) -> Result<*mut SCIP_Cons, Retcode> {
@@ -488,8 +488,8 @@ impl ScipPtr {
     }
     pub(crate) fn create_cons_indicator(
         &self,
-        bin_var: Rc<Variable>,
-        vars: Vec<Rc<Variable>>,
+        bin_var: &Variable,
+        vars: Vec<&Variable>,
         coefs: &mut [f64],
         rhs: f64,
         name: &str,
@@ -528,7 +528,7 @@ impl ScipPtr {
     pub(crate) fn add_cons_coef_setppc(
         &self,
         cons: Rc<Constraint>,
-        var: Rc<Variable>,
+        var: &Variable,
     ) -> Result<(), Retcode> {
         scip_call! { ffi::SCIPaddCoefSetppc(self.raw, cons.raw, var.raw) };
         Ok(())
@@ -1053,7 +1053,7 @@ impl ScipPtr {
     pub(crate) fn add_cons_coef(
         &self,
         cons: Rc<Constraint>,
-        var: Rc<Variable>,
+        var: &Variable,
         coef: f64,
     ) -> Result<(), Retcode> {
         let cons_is_transformed = unsafe { ffi::SCIPconsIsTransformed(cons.raw) } == 1;

--- a/src/scip.rs
+++ b/src/scip.rs
@@ -527,7 +527,7 @@ impl ScipPtr {
     /// Add coefficient to set packing/partitioning/covering constraint
     pub(crate) fn add_cons_coef_setppc(
         &self,
-        cons: Rc<Constraint>,
+        cons: &Constraint,
         var: &Variable,
     ) -> Result<(), Retcode> {
         scip_call! { ffi::SCIPaddCoefSetppc(self.raw, cons.raw, var.raw) };
@@ -1052,7 +1052,7 @@ impl ScipPtr {
 
     pub(crate) fn add_cons_coef(
         &self,
-        cons: Rc<Constraint>,
+        cons: &Constraint,
         var: &Variable,
         coef: f64,
     ) -> Result<(), Retcode> {
@@ -1089,7 +1089,7 @@ impl ScipPtr {
 
     pub(crate) fn set_cons_modifiable(
         &self,
-        cons: Rc<Constraint>,
+        cons: &Constraint,
         modifiable: bool,
     ) -> Result<(), Retcode> {
         scip_call!(ffi::SCIPsetConsModifiable(

--- a/src/scip.rs
+++ b/src/scip.rs
@@ -51,10 +51,27 @@ impl ScipPtr {
         Ok(())
     }
 
+    pub(crate) fn str_param(&self, param: &str) -> Result<&str, Retcode> {
+        let param = CString::new(param).unwrap();
+        let mut value_ptr = MaybeUninit::uninit();
+        scip_call! { ffi::SCIPgetStringParam(self.raw, param.as_ptr(), value_ptr.as_mut_ptr()) };
+        let value_ptr = unsafe { value_ptr.assume_init() };
+        let value = unsafe { CStr::from_ptr(value_ptr) };
+        Ok(value.to_str().unwrap())
+    }
+
     pub(crate) fn set_bool_param(&self, param: &str, value: bool) -> Result<(), Retcode> {
         let param = CString::new(param).unwrap();
         scip_call! { ffi::SCIPsetBoolParam(self.raw, param.as_ptr(), if value { 1u32 } else { 0u32 }) };
         Ok(())
+    }
+    
+    pub(crate) fn bool_param(&self, param: &str) -> Result<bool, Retcode> {
+        let param = CString::new(param).unwrap();
+        let mut value = MaybeUninit::uninit();
+        scip_call! { ffi::SCIPgetBoolParam(self.raw, param.as_ptr(), value.as_mut_ptr()) };
+        let value = unsafe { value.assume_init() };
+        Ok(value != 0)
     }
 
     pub(crate) fn set_int_param(&self, param: &str, value: i32) -> Result<(), Retcode> {
@@ -62,17 +79,41 @@ impl ScipPtr {
         scip_call! { ffi::SCIPsetIntParam(self.raw, param.as_ptr(), value) };
         Ok(())
     }
+    
+    pub(crate) fn int_param(&self, param: &str) -> Result<i32, Retcode> {
+        let param = CString::new(param).unwrap();
+        let mut value = MaybeUninit::uninit();
+        scip_call! { ffi::SCIPgetIntParam(self.raw, param.as_ptr(), value.as_mut_ptr()) };
+        let value = unsafe { value.assume_init() };
+        Ok(value)
+    }
 
     pub(crate) fn set_longint_param(&self, param: &str, value: i64) -> Result<(), Retcode> {
         let param = CString::new(param).unwrap();
         scip_call! { ffi::SCIPsetLongintParam(self.raw, param.as_ptr(), value) };
         Ok(())
     }
+    
+    pub(crate) fn longint_param(&self, param: &str) -> Result<i64, Retcode> {
+        let param = CString::new(param).unwrap();
+        let mut value = MaybeUninit::uninit();
+        scip_call! { ffi::SCIPgetLongintParam(self.raw, param.as_ptr(), value.as_mut_ptr()) };
+        let value = unsafe { value.assume_init() };
+        Ok(value)
+    }
 
     pub(crate) fn set_real_param(&self, param: &str, value: f64) -> Result<(), Retcode> {
         let param = CString::new(param).unwrap();
         scip_call! { ffi::SCIPsetRealParam(self.raw, param.as_ptr(), value) };
         Ok(())
+    }
+    
+    pub(crate) fn real_param(&self, param: &str) -> Result<f64, Retcode> {
+        let param = CString::new(param).unwrap();
+        let mut value = MaybeUninit::uninit();
+        scip_call! { ffi::SCIPgetRealParam(self.raw, param.as_ptr(), value.as_mut_ptr()) };
+        let value = unsafe { value.assume_init() };
+        Ok(value)
     }
 
     pub(crate) fn set_presolving(&self, presolving: ParamSetting) -> Result<(), Retcode> {

--- a/src/separator.rs
+++ b/src/separator.rs
@@ -148,7 +148,10 @@ impl SCIPSeparator {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{minimal_model, Model, ModelWithProblem, ObjSense, ProblemOrSolving, Solving, VarType, Variable};
+    use crate::{
+        minimal_model, Model, ModelWithProblem, ObjSense, ProblemOrSolving, Solving, VarType,
+        Variable,
+    };
 
     struct NotRunningSeparator;
 

--- a/src/separator.rs
+++ b/src/separator.rs
@@ -148,9 +148,7 @@ impl SCIPSeparator {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        minimal_model, Model, ModelWithProblem, ObjSense, ProblemOrSolving, Solving, VarType,
-    };
+    use crate::{minimal_model, Model, ModelWithProblem, ObjSense, ProblemOrSolving, Solving, VarType, Variable};
 
     struct NotRunningSeparator;
 
@@ -196,9 +194,10 @@ mod tests {
         ) -> SeparationResult {
             // adds a row representing the sum of all variables >= 1
             let vars = model.vars();
+            let var_refs: Vec<&Variable> = vars.iter().collect();
             let varlen = vars.len();
 
-            model.add_cons(vars, &vec![1.0; varlen], 5.0, 5.0, "cons_added");
+            model.add_cons(var_refs, &vec![1.0; varlen], 5.0, 5.0, "cons_added");
             SeparationResult::ConsAdded
         }
     }
@@ -212,7 +211,7 @@ mod tests {
         let x = model.add_var(0.0, 1.0, 1.0, "x", VarType::Binary);
         let y = model.add_var(0.0, 1.0, 1.0, "y", VarType::Binary);
 
-        model.add_cons(vec![x, y], &[1.0, 1.0], 1.0, 1.0, "cons1");
+        model.add_cons(vec![&x, &y], &[1.0, 1.0], 1.0, 1.0, "cons1");
 
         let sep = ConsAddingSeparator {};
 
@@ -313,7 +312,7 @@ mod tests {
         let x = model.add_var(0.0, 1.0, 1.0, "x", VarType::Binary);
         let y = model.add_var(0.0, 1.0, 1.0, "y", VarType::Binary);
 
-        model.add_cons(vec![x, y], &[1.0, 1.0], 1.0, 1.0, "cons1");
+        model.add_cons(vec![&x, &y], &[1.0, 1.0], 1.0, 1.0, "cons1");
 
         let sep = CutsAddingSeparator {};
 

--- a/src/solution.rs
+++ b/src/solution.rs
@@ -6,9 +6,10 @@ use crate::variable::Variable;
 use crate::{ffi, scip_call_panic};
 
 /// A wrapper for a SCIP solution.
+#[derive(Clone)]
 pub struct Solution {
-    pub(crate) scip_ptr: Rc<ScipPtr>,
     pub(crate) raw: *mut ffi::SCIP_SOL,
+    pub(crate) scip_ptr: Rc<ScipPtr>,
 }
 
 impl Solution {

--- a/src/solution.rs
+++ b/src/solution.rs
@@ -18,12 +18,12 @@ impl Solution {
     }
 
     /// Returns the value of a variable in the solution.
-    pub fn val(&self, var: Rc<Variable>) -> f64 {
+    pub fn val(&self, var: &Variable) -> f64 {
         unsafe { ffi::SCIPgetSolVal(self.scip_ptr.raw, self.raw, var.raw) }
     }
 
     /// Sets the value of a variable in the solution.
-    pub fn set_val(&self, var: Rc<Variable>, val: f64) {
+    pub fn set_val(&self, var: &Variable, val: f64) {
         scip_call_panic!(ffi::SCIPsetSolVal(
             self.scip_ptr.raw,
             self.raw,
@@ -123,8 +123,8 @@ mod tests {
         assert!(debug_str.contains("Var t_x2=20"));
 
         let vars = model.vars();
-        assert_eq!(sol.val(vars[0].clone()), 40.);
-        assert_eq!(sol.val(vars[1].clone()), 20.);
+        assert_eq!(sol.val(&vars[0]), 40.);
+        assert_eq!(sol.val(&vars[1]), 20.);
 
         assert_eq!(sol.obj_val(), model.obj_val());
 

--- a/src/variable.rs
+++ b/src/variable.rs
@@ -8,7 +8,7 @@ use std::rc::Rc;
 pub type VarId = usize;
 
 /// A wrapper for a mutable reference to a SCIP variable.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[allow(dead_code)]
 pub struct Variable {
     pub(crate) raw: *mut ffi::SCIP_VAR,
@@ -204,7 +204,7 @@ mod tests {
     fn var_sol_val() {
         let mut model = minimal_model();
         let x = model.add_var(0.0, 1.0, 1.0, "x", VarType::Binary);
-        let _cons = model.add_cons(vec![x.clone()], &[1.0], 1.0, 1.0, "cons1");
+        let _cons = model.add_cons(vec![&x], &[1.0], 1.0, 1.0, "cons1");
 
         model.solve();
 


### PR DESCRIPTION
This is to later give mutable access to the `Variable` and `Constraint` objects. 