### PR TITLE
Add missing clone implementations

### DIFF
--- a/src/col.rs
+++ b/src/col.rs
@@ -4,7 +4,8 @@ use crate::scip::ScipPtr;
 use crate::{ffi, Variable};
 use std::rc::Rc;
 
-/// A column in the LP relaxation.
+/// A column in the LP relaxation.u
+#[derive(Debug, Clone)]
 pub struct Col {
     pub(crate) raw: *mut ffi::SCIP_COL,
     pub(crate) scip: Rc<ScipPtr>,

--- a/src/model.rs
+++ b/src/model.rs
@@ -407,7 +407,11 @@ impl Model<Solving> {
     ///
     /// This method panics if not called in the `Solving` state, it should only be used from plugins implementations.
     pub fn focus_node(&self) -> Node {
-        self.scip.focus_node()
+        let scip_node = self.scip.focus_node().expect("Failed to get focus node");
+        Node {
+            raw: scip_node,
+            scip: self.scip.clone(),
+        }
     }
 
     /// Creates a new child node of the current node and returns it.
@@ -416,9 +420,14 @@ impl Model<Solving> {
     ///
     /// This method panics if not called from plugins implementations.
     pub fn create_child(&mut self) -> Node {
-        self.scip
+        let node_ptr = self.scip
             .create_child()
-            .expect("Failed to create child node in state ProblemCreated")
+            .expect("Failed to create child node in state ProblemCreated");
+        
+        Node {
+            raw: node_ptr,
+            scip: self.scip.clone(),
+        }
     }
 
     /// Adds a new priced variable to the SCIP data structure.

--- a/src/model.rs
+++ b/src/model.rs
@@ -420,10 +420,11 @@ impl Model<Solving> {
     ///
     /// This method panics if not called from plugins implementations.
     pub fn create_child(&mut self) -> Node {
-        let node_ptr = self.scip
+        let node_ptr = self
+            .scip
             .create_child()
             .expect("Failed to create child node in state ProblemCreated");
-        
+
         Node {
             raw: node_ptr,
             scip: self.scip.clone(),

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,6 +1,6 @@
-use std::rc::Rc;
 use crate::ffi;
 use crate::scip::ScipPtr;
+use std::rc::Rc;
 
 /// A node in the branch-and-bound tree.
 #[derive(Debug, Clone)]
@@ -36,7 +36,10 @@ impl Node {
         if parent.is_null() {
             None
         } else {
-            Some(Node { raw: parent, scip: self.scip.clone() })
+            Some(Node {
+                raw: parent,
+                scip: self.scip.clone(),
+            })
         }
     }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,8 +1,12 @@
+use std::rc::Rc;
 use crate::ffi;
+use crate::scip::ScipPtr;
 
 /// A node in the branch-and-bound tree.
+#[derive(Debug, Clone)]
 pub struct Node {
     pub(crate) raw: *mut ffi::SCIP_NODE,
+    pub(crate) scip: Rc<ScipPtr>,
 }
 
 impl Node {
@@ -32,7 +36,7 @@ impl Node {
         if parent.is_null() {
             None
         } else {
-            Some(Node { raw: parent })
+            Some(Node { raw: parent, scip: self.scip.clone() })
         }
     }
 }

--- a/src/row.rs
+++ b/src/row.rs
@@ -4,6 +4,7 @@ use std::ffi::c_int;
 use std::rc::Rc;
 
 /// A row in the LP relaxation.
+#[derive(Debug, Clone)]
 pub struct Row {
     pub(crate) raw: *mut ffi::SCIP_ROW,
     pub(crate) scip: Rc<ScipPtr>,


### PR DESCRIPTION
Also adds a reference of ScipPtr to the Node struct, to protect the underlying SCIP model from being freed while the node object is still accessible. 