### PR TITLE
Probing mode methods

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,8 @@ pub mod builder;
 
 /// Contains the `Conshdlr` trait used to define custom constraint handlers.
 pub mod conshdlr;
+mod probing;
+
 pub use conshdlr::*;
 
 pub use row::*;

--- a/src/model.rs
+++ b/src/model.rs
@@ -14,6 +14,7 @@ use crate::{ffi, Row, Separator};
 use crate::{BranchRule, HeurTiming, Heuristic, Pricer};
 use scip_sys::SCIP;
 use std::rc::Rc;
+use crate::probing::Prober;
 
 /// Represents an optimization model.
 #[non_exhaustive]
@@ -608,6 +609,18 @@ impl Model<Solving> {
     /// Value of the variable.
     pub fn current_val(&self, var: &Variable) -> f64 {
         unsafe { ffi::SCIPgetSolVal(self.scip_ptr(), std::ptr::null_mut(), var.inner()) }
+    }
+
+    /// Starts probing at the current node.
+    ///
+    /// # Returns
+    /// A `Prober` instance that can be used to access methods allowed only in probing mode.
+    pub fn start_probing(&mut self) -> Prober {
+        let scip = self.scip.clone();
+
+        unsafe { ffi::SCIPstartProbing(scip.raw) };
+
+        Prober { scip }
     }
 }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -4,6 +4,7 @@ use crate::constraint::Constraint;
 use crate::eventhdlr::Eventhdlr;
 use crate::node::Node;
 use crate::param::ScipParameter;
+use crate::probing::Prober;
 use crate::retcode::Retcode;
 use crate::scip::ScipPtr;
 use crate::solution::{SolError, Solution};
@@ -14,7 +15,6 @@ use crate::{ffi, Row, Separator};
 use crate::{BranchRule, HeurTiming, Heuristic, Pricer};
 use scip_sys::SCIP;
 use std::rc::Rc;
-use crate::probing::Prober;
 
 /// Represents an optimization model.
 #[non_exhaustive]

--- a/src/model.rs
+++ b/src/model.rs
@@ -622,6 +622,11 @@ impl Model<Solving> {
 
         Prober { scip }
     }
+
+    /// Returns the objective value of the current LP relaxation.
+    pub fn lp_obj_val(&self) -> f64 {
+        unsafe { ffi::SCIPgetLPObjval(self.scip.raw) }
+    }
 }
 
 impl Model<Solved> {

--- a/src/probing.rs
+++ b/src/probing.rs
@@ -151,11 +151,19 @@ impl Prober {
         }
         let mut cutoff = 0;
         let mut lperror = 0;
+
+        // set a default for now to communicate the current state, any further needed communication
+        // can be done by sharing data between plugins
+        const PRETENDATROOT: u32 = 0;
+
+        // enable always for now, to avoid unnecessary complexity
+        const DISPLAYINFO: u32 = 1;
+
         unsafe {
             ffi::SCIPsolveProbingLPWithPricing(
                 self.scip.raw,
-                0,
-                1,
+                PRETENDATROOT,
+                DISPLAYINFO,
                 rounds,
                 &mut cutoff,
                 &mut lperror,

--- a/src/probing.rs
+++ b/src/probing.rs
@@ -227,7 +227,7 @@ mod tests {
                 drop(prober);
 
                 // have to use unsafe here as the method is not available in the public API
-                assert!(unsafe { ffi::SCIPinProbing(model.scip_ptr().into()) == 0 });
+                assert_eq!(unsafe { ffi::SCIPinProbing(model.scip_ptr()) }, 0);
             }
         }
 

--- a/src/probing.rs
+++ b/src/probing.rs
@@ -1,5 +1,5 @@
 use crate::scip::ScipPtr;
-use crate::{ffi, scip_call, Retcode, Variable};
+use crate::{ffi, Retcode, Variable};
 use std::rc::Rc;
 
 /// Struct giving access to methods allowed in probing mode

--- a/src/probing.rs
+++ b/src/probing.rs
@@ -1,0 +1,182 @@
+use crate::scip::ScipPtr;
+use crate::{ffi, scip_call, Retcode, Variable};
+use std::rc::Rc;
+
+/// Struct giving access to methods allowed in probing mode
+pub struct Prober {
+    pub(crate) scip: Rc<ScipPtr>,
+}
+
+impl Prober {
+    /// Creates a new probing (sub-)node, whose changes can be undone by backtracking to a higher node
+    /// in the probing path with a call to the `backtrack()` method.
+    pub fn new_node(&mut self) {
+        unsafe { ffi::SCIPnewProbingNode(self.scip.raw) };
+    }
+
+    /// Returns the current probing depth
+    pub fn depth(&self) -> usize {
+        unsafe { ffi::SCIPgetProbingDepth(self.scip.raw) }
+            .try_into()
+            .expect("Invalid depth value")
+    }
+
+    /// Undoes all changes to the problem applied in probing up to the given probing depth;
+    /// the changes of the probing node of the given probing depth are the last ones that remain active;
+    /// changes that were applied before calling `new_node()` cannot be undone
+    pub fn backtrack(&mut self, depth: usize) {
+        assert!(
+            depth < self.depth(),
+            "Probing depth must be less than the current probing depth."
+        );
+        unsafe { ffi::SCIPbacktrackProbing(self.scip.raw, depth.try_into().unwrap()) };
+    }
+
+    /// Changes the lower bound of a variable in the current probing node
+    pub fn chg_var_lb(&mut self, var: &Variable, new_bound: f64) {
+        unsafe { ffi::SCIPchgVarLbProbing(self.scip.raw, var.inner(), new_bound) };
+    }
+
+    /// Changes the upper bound of a variable in the current probing node
+    pub fn chg_var_ub(&mut self, var: &Variable, new_bound: f64) {
+        unsafe { ffi::SCIPchgVarUbProbing(self.scip.raw, var.inner(), new_bound) };
+    }
+
+    /// Retrieves the objective value of a variable in the current probing node
+    pub fn var_obj(&self, var: &Variable) -> f64 {
+        unsafe { ffi::SCIPgetVarObjProbing(self.scip.raw, var.inner()) }
+    }
+
+    /// Fixes a variable to a value in the current probing node
+    pub fn fix_var(&mut self, var: &Variable, value: f64) {
+        unsafe { ffi::SCIPfixVarProbing(self.scip.raw, var.inner(), value) };
+    }
+
+    /// Changes the objective value of a variable in the current probing node
+    pub fn chg_var_obj(&mut self, var: &Variable, new_obj: f64) {
+        unsafe { ffi::SCIPchgVarObjProbing(self.scip.raw, var.inner(), new_obj) };
+    }
+
+    /// Returns whether the probing subproblem objective function has been changed
+    pub fn is_obj_changed(&self) -> bool {
+        unsafe { ffi::SCIPisObjChangedProbing(self.scip.raw) != 0 }
+    }
+
+    /// Applies domain propagation on the probing subproblem; the propagated domains of the variables
+    /// can be accessed with the usual bound accessing calls to `var.lb_local()` and `var.ub_local()`
+    ///
+    /// # Arguments
+    /// - `max_rounds`: the maximum number of rounds to be performed, or `None` for no limit
+    ///
+    /// # Returns
+    /// A tuple (`cutoff`, `nreductions_found`)
+    /// - `cutoff`: whether a cutoff was detected
+    /// - `nreductions_found`: the number of reductions found
+    pub fn propagate(&mut self, max_rounds: Option<usize>) -> (bool, usize) {
+        let mut cutoff = 0;
+        let mut nreductions_found = 0;
+        let mut r = -1;
+        if let Some(rounds) = max_rounds {
+            r = rounds.try_into().unwrap();
+        }
+        unsafe {
+            ffi::SCIPpropagateProbing(self.scip.raw, r, &mut cutoff, &mut nreductions_found);
+        }
+
+        (cutoff != 0, nreductions_found.try_into().unwrap())
+    }
+
+    /// Applies domain propagation on the probing subproblem; only propagations of the binary variables
+    /// fixed at the current probing node that are triggered by the implication graph and the clique
+    /// table are applied; the propagated domains of the variables can be accessed with the usual
+    /// bound accessing calls to `var.lb_local()` and `var.ub_local()`
+    ///
+    /// # Returns
+    /// - `cutoff`: whether a cutoff was detected
+    pub fn propagate_implications(&mut self) -> bool {
+        let mut cutoff = 0;
+        unsafe {
+            ffi::SCIPpropagateProbingImplications(self.scip.raw, &mut cutoff);
+        }
+
+        cutoff != 0
+    }
+
+    /// Solves the probing subproblem; the solution can be accessed with the `model.current_val()` method
+    ///
+    /// # Arguments
+    /// - `iteration_limit`: the maximum number of iterations to be performed, or `None` for no limit
+    ///
+    /// # Returns
+    /// - `cutoff`: whether a cutoff was detected
+    pub fn solve_lp(&mut self, iteration_limit: Option<usize>) -> Result<bool, Retcode> {
+        if !self.scip.is_lp_constructed() {
+            self.scip.construct_lp()?;
+        }
+
+        let mut limit = -1;
+        if let Some(iterations) = iteration_limit {
+            limit = iterations.try_into().unwrap();
+        }
+        let mut cutoff = 0;
+        let mut lperror = 0;
+        unsafe { ffi::SCIPsolveProbingLP(self.scip.raw, limit, &mut cutoff, &mut lperror) };
+
+        if lperror != 0 {
+            return Err(Retcode::LpError);
+        }
+
+        Ok(cutoff != 0)
+    }
+
+    /// Solves the probing subproblem with pricing; the solution can be accessed
+    /// with the `model.current_val()` method.
+    ///
+    /// # Arguments
+    /// - `max_pricing_rounds`: the maximum number of pricing rounds to be performed, or `None` for no limit
+    ///
+    /// # Returns
+    /// - `cutoff`: whether a cutoff was detected
+    pub fn solve_lp_with_pricing(
+        &mut self,
+        max_pricing_rounds: Option<usize>,
+    ) -> Result<bool, Retcode> {
+        if !self.scip.is_lp_constructed() {
+            self.scip.construct_lp()?;
+        }
+
+        let mut rounds = -1;
+        if let Some(r) = max_pricing_rounds {
+            rounds = r.try_into().unwrap();
+        }
+        let mut cutoff = 0;
+        let mut lperror = 0;
+        unsafe {
+            ffi::SCIPsolveProbingLPWithPricing(
+                self.scip.raw,
+                0,
+                1,
+                rounds,
+                &mut cutoff,
+                &mut lperror,
+            )
+        };
+
+        if lperror != 0 {
+            return Err(Retcode::LpError);
+        }
+
+        Ok(cutoff != 0)
+    }
+}
+
+impl Drop for Prober {
+    fn drop(&mut self) {
+        assert_eq!(
+            unsafe { ffi::SCIPinProbing(self.scip.raw) },
+            1,
+            "SCIP is expected to be in probing mode before Prober is dropped."
+        );
+        unsafe { ffi::SCIPendProbing(self.scip.raw) };
+    }
+}

--- a/src/scip.rs
+++ b/src/scip.rs
@@ -340,6 +340,16 @@ impl ScipPtr {
         Ok(trans_var_ptr)
     }
 
+    pub(crate) fn is_lp_constructed(&self) -> bool {
+        unsafe { ffi::SCIPisLPConstructed(self.raw) != 0 }
+    }
+
+    pub(crate) fn construct_lp(&self) -> Result<Option<bool>, Retcode> {
+        let mut cutoff = 0;
+        scip_call! { ffi::SCIPconstructLP(self.raw, &mut cutoff) }
+        Ok(Some(cutoff != 0))
+    }
+
     pub(crate) fn create_priced_var(
         &self,
         lb: f64,


### PR DESCRIPTION
Gives access to SCIP's probing mode, through the method `model.start_probing()` which gives you a `Prober` object that allows access to probing methods, like changing the variable bounds or objective function coefficient and creating (temporary) sub-nodes e.g. to explore the effect of branching. 

The probing mode is exited automatically when the `Prober` object is dropped. 