### PR TITLE
feat: Use NonNull for SCIP_SOL pointer in Solution struct

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -1386,7 +1386,8 @@ impl<S: ModelStageWithSolutions> WithSolutions for Model<S> {
         if self.n_sols() > 0 {
             let sol = Solution {
                 scip_ptr: self.scip.clone(),
-                raw: std::ptr::NonNull::new(self.scip.best_sol().unwrap()).expect("SCIP returned null pointer for best solution"),
+                raw: std::ptr::NonNull::new(self.scip.best_sol().unwrap())
+                    .expect("SCIP returned null pointer for best solution"),
             };
             Some(sol)
         } else {
@@ -1408,7 +1409,8 @@ impl<S: ModelStageWithSolutions> WithSolutions for Model<S> {
                 .unwrap()
                 .into_iter()
                 .map(|x| Solution {
-                    raw: std::ptr::NonNull::new(x).expect("SCIP returned null pointer for solution"),
+                    raw: std::ptr::NonNull::new(x)
+                        .expect("SCIP returned null pointer for solution"),
                     scip_ptr: self.scip.clone(),
                 })
                 .collect::<Vec<_>>()

--- a/src/scip.rs
+++ b/src/scip.rs
@@ -1484,7 +1484,11 @@ impl ScipPtr {
                 true.into(),
             ));
             if feasible == 1 {
-                scip_call!(ffi::SCIPaddSolFree(self.raw, &mut sol.raw.as_ptr(), &mut feasible));
+                scip_call!(ffi::SCIPaddSolFree(
+                    self.raw,
+                    &mut sol.raw.as_ptr(),
+                    &mut feasible
+                ));
             }
             return Ok(feasible != 0);
         } else {


### PR DESCRIPTION
Resolves #157

This PR replaces the raw pointer (*mut ffi::SCIP_SOL) with NonNull<ffi::SCIP_SOL> in the Solution struct to provide stronger null-safety guarantees.

