### PR TITLE
resolves #261: replace dependency `anymap` by `anymap3`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,11 @@ exclude = ["data/test/*"]
 default = ["datastore"]
 bundled = ["scip-sys/bundled"]
 from-source = ["scip-sys/from-source"]
-datastore = ["anymap"]
+datastore = ["anymap3"]
 
 [dependencies]
 scip-sys = "0.1.21"
-anymap = { version = "0.12.0", optional = true }
+anymap3 = { version = "1.0.1", optional = true }
 
 [dev-dependencies]
 rayon = "1.5.1"

--- a/src/scip.rs
+++ b/src/scip.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "datastore")]
-use anymap::AnyMap;
+use anymap3::AnyMap;
 
 use crate::branchrule::{BranchRule, BranchingCandidate};
 use crate::node::Node;


### PR DESCRIPTION
Replaces dependency `anymap` that has a critical vulnerability ([CVE-2021-38187](https://github.com/advisories/GHSA-hc92-9h3m-c39j)). `anymap3` is a fork of the unmaintained `anymap`. It mostly shares the same API, so there's no need to adapt any Rust code in `russcip`.