### PR TITLE
Use PhantomData to store the Model typestate

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -14,6 +14,7 @@ use crate::{BranchRule, HeurTiming, Heuristic, Pricer};
 use crate::{Conshdlr, Diver};
 use crate::{Row, Separator, ffi, scip_call_panic};
 use scip_sys::SCIP;
+use std::marker::PhantomData;
 use std::rc::Rc;
 
 /// Represents an optimization model.
@@ -21,8 +22,7 @@ use std::rc::Rc;
 #[derive(Debug)]
 pub struct Model<State> {
     pub(crate) scip: Rc<ScipPtr>,
-    #[allow(dead_code)]
-    pub(crate) state: State,
+    pub(crate) state: PhantomData<State>,
 }
 
 /// Represents the state of an optimization model that has not yet been solved.
@@ -58,7 +58,7 @@ impl Model<Unsolved> {
         let scip_ptr = ScipPtr::new()?;
         Ok(Model {
             scip: Rc::new(scip_ptr),
-            state: Unsolved {},
+            state: PhantomData,
         })
     }
 }
@@ -80,7 +80,7 @@ impl Model<PluginsIncluded> {
             .expect("Failed to create problem in state PluginsIncluded");
         Model {
             scip,
-            state: ProblemCreated {},
+            state: PhantomData,
         }
     }
 
@@ -99,7 +99,7 @@ impl Model<PluginsIncluded> {
         scip.read_prob(filename)?;
         let new_model = Model {
             scip: self.scip,
-            state: ProblemCreated {},
+            state: PhantomData,
         };
         Ok(new_model)
     }
@@ -377,7 +377,7 @@ impl Model<ProblemCreated> {
             .expect("Failed to solve problem in state ProblemCreated");
         Model {
             scip: self.scip,
-            state: Solved {},
+            state: PhantomData,
         }
     }
 }
@@ -693,7 +693,7 @@ impl Model<Solved> {
             .unwrap_or_else(|retcode| panic!("SCIP returned unexpected retcode {retcode:?}"));
         Model {
             scip: self.scip,
-            state: ProblemCreated {},
+            state: PhantomData,
         }
     }
 }
@@ -1616,7 +1616,7 @@ impl<T> Model<T> {
             .expect("Failed to include default plugins");
         Model {
             scip: self.scip,
-            state: PluginsIncluded {},
+            state: PhantomData,
         }
     }
 

--- a/src/scip.rs
+++ b/src/scip.rs
@@ -7,7 +7,7 @@ use crate::pricer::{Pricer, PricerResultState};
 use crate::{
     BranchingResult, Conshdlr, Constraint, Event, Eventhdlr, HeurResult, LPStatus, Model, ObjSense,
     ParamSetting, Retcode, Row, SCIPBranchRule, SCIPConshdlr, SCIPEventhdlr, SCIPPricer,
-    SCIPSeparator, Separator, Solution, Solving, Status, VarType, Variable, ffi, scip_call_panic,
+    SCIPSeparator, Separator, Solution, Status, VarType, Variable, ffi, scip_call_panic,
 };
 use crate::{HeurTiming, Heuristic, scip_call};
 use core::panic;
@@ -17,6 +17,7 @@ use scip_sys::{
 };
 use std::collections::BTreeMap;
 use std::ffi::{CStr, CString, c_int};
+use std::marker::PhantomData;
 use std::mem::MaybeUninit;
 use std::rc::Rc;
 
@@ -759,7 +760,7 @@ impl ScipPtr {
             let scip_ptr = Rc::new(ScipPtr::from_raw(scip, true));
             let model = Model {
                 scip: scip_ptr.clone(),
-                state: Solving,
+                state: PhantomData,
             };
             let eventhdlr = SCIPEventhdlr { raw: eventhdlr };
             let event = Event {
@@ -858,7 +859,7 @@ impl ScipPtr {
             let scip_ptr = ScipPtr::from_raw(scip, true);
             let model = Model {
                 scip: Rc::new(scip_ptr),
-                state: Solving,
+                state: PhantomData,
             };
             let branchrule = SCIPBranchRule { raw: branchrule };
             let branching_res = unsafe { (*rule_ptr).execute(model, branchrule, cands) };
@@ -943,7 +944,7 @@ impl ScipPtr {
             let scip_ptr = ScipPtr::from_raw(scip, true);
             let model = Model {
                 scip: Rc::new(scip_ptr),
-                state: Solving,
+                state: PhantomData,
             };
 
             let pricer = SCIPPricer { raw: pricer };
@@ -1066,7 +1067,7 @@ impl ScipPtr {
             let scip_ptr = ScipPtr::from_raw(scip, true);
             let model = Model {
                 scip: Rc::new(scip_ptr),
-                state: Solving,
+                state: PhantomData,
             };
             let heur_res =
                 unsafe { (*rule_ptr).execute(model, heurtiming.into(), nodeinfeasible != 0) };
@@ -1152,7 +1153,7 @@ impl ScipPtr {
             let scip_ptr = ScipPtr::from_raw(scip, true);
             let model = Model {
                 scip: Rc::new(scip_ptr),
-                state: Solving,
+                state: PhantomData,
             };
             let separator = SCIPSeparator { raw: separator };
             let sep_res = unsafe { (*rule_ptr).execute_lp(model, separator) };
@@ -1236,7 +1237,7 @@ impl ScipPtr {
             let scip_ptr = Rc::new(ScipPtr::from_raw(scip, true));
             let model = Model {
                 scip: scip_ptr.clone(),
-                state: Solving,
+                state: PhantomData,
             };
 
             let scip_conshdlr = SCIPConshdlr { raw: conshdlr };
@@ -1267,7 +1268,7 @@ impl ScipPtr {
             let scip_ptr = Rc::new(ScipPtr::from_raw(scip, true));
             let model = Model {
                 scip: scip_ptr.clone(),
-                state: Solving,
+                state: PhantomData,
             };
 
             let scip_conshdlr = SCIPConshdlr { raw: conshdlr };


### PR DESCRIPTION
Using a `_` prefixed identifier, feels more idiomatic than an `allow(dead_code)`

No API change.