### PR TITLE
Add Model::try_solve for fallible solving on ProblemCreated

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -2014,6 +2014,12 @@ mod tests {
     }
 
     #[test]
+    fn try_solve_on_valid_model() {
+        let solved = create_model().try_solve().unwrap();
+        assert_eq!(solved.status(), Status::Optimal);
+    }
+
+    #[test]
     fn build_model_with_functions() {
         let model = create_model();
         assert_eq!(model.vars().len(), 2);

--- a/src/model.rs
+++ b/src/model.rs
@@ -361,6 +361,21 @@ impl Model<ProblemCreated> {
             .expect("Failed to include constraint handler at state ProblemCreated");
     }
 
+    /// Tries to solve the model, and returns a new `Model` instance with a `Solved` state if successful.
+    ///
+    /// # Returns
+    ///
+    /// A new `Model` instance with a `Solved` state, or a [`Retcode`] if the problem cannot be solved in the current state.
+    #[allow(unused_mut)]
+    pub fn try_solve(mut self) -> Result<Model<Solved>, Retcode> {
+        self.scip.solve()?;
+
+        Ok(Model {
+            scip: self.scip,
+            state: PhantomData,
+        })
+    }
+
     /// Solves the model and returns a new `Model` instance with a `Solved` state.
     ///
     /// # Returns
@@ -372,13 +387,8 @@ impl Model<ProblemCreated> {
     /// This method panics if the problem cannot be solved in the current state.
     #[allow(unused_mut)]
     pub fn solve(mut self) -> Model<Solved> {
-        self.scip
-            .solve()
-            .expect("Failed to solve problem in state ProblemCreated");
-        Model {
-            scip: self.scip,
-            state: PhantomData,
-        }
+        self.try_solve()
+            .expect("Failed to solve problem in state ProblemCreated")
     }
 }
 


### PR DESCRIPTION
## Summary

Adds a fallible `try_solve` method on `Model<ProblemCreated>` that surfaces SCIP API failures as `Result<Model<Solved>, Retcode>` instead of panicking. Keeps the existing `solve()` API unchanged for backward compatibility.

## Motivation

Downstream crates (e.g. [good_lp](https://github.com/rust-or/good_lp)) implement `SolverModel::solve` as `Result<_, E>`. Consumers expect optimization failures (infeasible, unbounded, time limit, etc.) to come back as `Err`, not as a thread panic.

Today, `Model::solve` calls the internal fallible `ScipPtr::solve()` but turns any error into a panic:

```rust
pub fn solve(mut self) -> Model<Solved> {
    self.scip
        .solve()
        .expect("Failed to solve problem in state ProblemCreated");
    Model { scip: self.scip, state: Solved {} }
}
```

The low-level path already returns `Result<(), Retcode>`; only the public `Model::solve` wrapper is panicking. Wrappers like good_lp currently work around this with `catch_unwind`, which is brittle (no `Retcode`, catches unrelated panics, breaks with `panic = "abort"`).

This PR exposes the fallible path explicitly, consistent with existing APIs such as `Model::try_new()` and `try_set_param`.

## Proposed API

On `impl Model<ProblemCreated>`:

```rust
/// Solves the model and returns a new `Model` in the `Solved` state.
///
/// Returns `Err(Retcode)` if SCIP cannot run the solve in the current state
/// (e.g. invalid call, missing problem, internal SCIP error).
pub fn try_solve(mut self) -> Result<Model<Solved>, Retcode> {
    self.scip.solve()?;
    Ok(Model {
        scip: self.scip,
        state: Solved {},
    })
}

/// Solves the model and returns a new `Model` instance with a `Solved` state.
///
/// # Panics
///
/// Panics if SCIP returns an error when starting the solve. For a non-panicking
/// alternative, use [`try_solve`](Self::try_solve).
pub fn solve(mut self) -> Model<Solved> {
    self.try_solve()
        .expect("Failed to solve problem in state ProblemCreated");
}
```

**Note:** `try_solve` reports **SCIP API / call failures** (`Retcode`). Optimization outcomes (infeasible, optimal, time limit, etc.) remain available via `Model<Solved>::status()` after a successful `try_solve`, unchanged from today.

## Implementation

- Reuse existing `ScipPtr::solve() -> Result<(), Retcode>` (no FFI changes).
- Refactor `solve()` to delegate to `try_solve().expect(...)`.

## Backward compatibility

- **No breaking changes.** `solve()` behavior is unchanged for callers that already use it.

## Related work

- [good_lp PR ](https://github.com/rust-or/good_lp/pull/125)- removes `catch_unwind` around `Model::solve` once this is released and good_lp can depend on the new version.

## Changelog

```markdown
### Added
- `Model<ProblemCreated>::try_solve`, a fallible alternative to `Model::solve` that returns `Result<Model<Solved>, Retcode>`.
```