### PR TITLE
Support SCIP 10.0.2

### DIFF
--- a/.github/lsan-suppressions.txt
+++ b/.github/lsan-suppressions.txt
@@ -11,3 +11,6 @@ leak:computeAutomorphisms
 leak:sparsenauty
 leak:refine_sg
 leak:nauty
+leak:doref
+leak:firstpathnode0
+leak:preparemarks1

--- a/.github/lsan-suppressions.txt
+++ b/.github/lsan-suppressions.txt
@@ -1,0 +1,13 @@
+# LeakSanitizer suppressions for the conda CI job.
+#
+# SCIP 10's symmetry detection (the bundled nauty/dejavu code reached via
+# SCIPpresolve -> ... -> SYMcomputeSymmetryGenerators -> computeAutomorphisms)
+# leaks its internal graph allocations; they are not freed even after SCIPfree.
+# This is internal to SCIP, not russcip (there is no russcip-owned handle to
+# release), and only the SCIP symmetry path is suppressed here -- every other
+# allocation site is still leak-checked.
+leak:SYMcomputeSymmetryGenerators
+leak:computeAutomorphisms
+leak:sparsenauty
+leak:refine_sg
+leak:nauty

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,7 +1,7 @@
 name: russcip_pipelines
 
 env:
-  version: 9.2.4
+  version: 10.0.2
   RUST_VERSION: 1.88.0
 
 on:
@@ -26,9 +26,9 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install dependencies (SCIPOptSuite)
         run: |
-          wget --quiet --no-check-certificate https://github.com/scipopt/scip/releases/download/$(echo "v${{env.version}}" | tr -d '.')/SCIPOptSuite-${{ env.version }}-Linux-ubuntu22.deb
+          wget --quiet --no-check-certificate https://github.com/scipopt/scip/releases/download/v${{ env.version }}/scipoptsuite_${{ env.version }}-1+jammy_amd64.deb
           sudo apt-get update
-          sudo apt install -y ./SCIPOptSuite-${{ env.version }}-Linux-ubuntu22.deb
+          sudo apt install -y ./scipoptsuite_${{ env.version }}-1+jammy_amd64.deb
 
       - name: Install rust stable toolchain
         uses: actions-rs/toolchain@v1
@@ -59,7 +59,7 @@ jobs:
 
       - name: Install dependencies (SCIPOptSuite)
         run: |
-          conda install -y --prefix $CONDA/envs/test --channel conda-forge scip=9.2.4
+          conda install -y --prefix $CONDA/envs/test --channel conda-forge scip=10.0.2
           echo "LD_LIBRARY_PATH=$CONDA/envs/test/lib" >> "${GITHUB_ENV}"
           echo "CONDA_PREFIX=$CONDA/envs/test" >> "${GITHUB_ENV}"
 
@@ -93,7 +93,7 @@ jobs:
 
       - name: Download dependencies (SCIPOptSuite)
         shell: powershell
-        run: wget https://github.com/scipopt/scip/releases/download/$(echo "v${{env.version}}" | tr -d '.')/SCIPOptSuite-${{ env.version }}-win64.exe -outfile scipopt-installer.exe
+        run: wget https://github.com/scipopt/scip/releases/download/v${{ env.version }}/scipoptsuite-${{ env.version }}-win-x64.exe -outfile scipopt-installer.exe
 
       - name: Install dependencies (SCIPOptSuite)
         shell: cmd

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Test
         run: |
           rustup toolchain install nightly
-          RUSTFLAGS=-Zsanitizer=leak cargo +nightly test 
+          LSAN_OPTIONS=suppressions=$PWD/.github/lsan-suppressions.txt RUSTFLAGS=-Zsanitizer=leak cargo +nightly test
 
   linux-bundled-test:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -70,7 +70,13 @@ jobs:
       - name: Test
         run: |
           rustup toolchain install nightly
-          LSAN_OPTIONS=suppressions=$PWD/.github/lsan-suppressions.txt RUSTFLAGS=-Zsanitizer=leak cargo +nightly test
+          # LeakSanitizer needs llvm-symbolizer to resolve libscip frames so the
+          # symmetry-leak suppressions (matched by function name) can apply.
+          sudo apt-get update && sudo apt-get install -y llvm
+          SYMBOLIZER="$(command -v llvm-symbolizer || ls /usr/bin/llvm-symbolizer-* | head -1)"
+          echo "Using symbolizer: $SYMBOLIZER"
+          export LSAN_OPTIONS="suppressions=$PWD/.github/lsan-suppressions.txt:external_symbolizer_path=$SYMBOLIZER:symbolize=1"
+          RUSTFLAGS=-Zsanitizer=leak cargo +nightly test
 
   linux-bundled-test:
     if: github.event.pull_request.draft == false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ from-source = ["scip-sys/from-source"]
 datastore = ["anymap3"]
 
 [dependencies]
-scip-sys = "0.1.26"
+scip-sys = "0.1.27"
 anymap3 = { version = "1.0.1", optional = true }
 
 [dev-dependencies]

--- a/src/col.rs
+++ b/src/col.rs
@@ -186,11 +186,17 @@ impl PartialEq for Col {
 mod tests {
     use crate::prelude::eventhdlr;
     use crate::{
-        BasisStatus, Event, EventMask, Eventhdlr, Model, ModelWithProblem, ProblemOrSolving,
-        SCIPEventhdlr, Solving, VarType, minimal_model,
+        BasisStatus, Event, EventMask, Eventhdlr, Model, ModelWithProblem, ObjSense, ParamSetting,
+        ProblemOrSolving, SCIPEventhdlr, Solving, VarType,
     };
+    use std::rc::Rc;
+    use std::sync::atomic::{AtomicBool, Ordering};
 
-    struct ColTesterEventHandler;
+    struct ColTesterEventHandler {
+        /// Set once the column assertions have actually run, so the test cannot
+        /// pass vacuously if the inspected column is never in the LP.
+        checked: Rc<AtomicBool>,
+    }
 
     impl Eventhdlr for ColTesterEventHandler {
         fn get_type(&self) -> EventMask {
@@ -199,45 +205,76 @@ mod tests {
 
         fn execute(&mut self, model: Model<Solving>, _eventhdlr: SCIPEventhdlr, event: Event) {
             assert_eq!(event.event_type(), EventMask::FIRST_LP_SOLVED);
+            // Since SCIP 10 this event also fires for the initial (empty) LP, where
+            // the variables are still loose; only inspect once x1 is an LP column.
             let vars = model.vars();
-            let first_var = vars[0].clone();
-            let col = first_var.col().unwrap();
+            let Some(col) = vars[0].col() else { return };
+
             assert_eq!(col.index(), 0);
-            assert_eq!(col.index(), 0);
-            assert_eq!(col.index(), 0);
-            assert_eq!(col.obj(), 1.0);
+            // The model maximizes, which SCIP stores internally as minimizing the
+            // negated objective, so the column objective is -3 (not 3).
+            assert_eq!(col.obj(), -3.0);
             assert_eq!(col.lb(), 0.0);
-            assert_eq!(col.ub(), 1.0);
-            assert_eq!(col.best_bound(), 0.0);
-            assert_eq!(col.primal_sol(), 1.0);
-            assert_eq!(col.min_primal_sol(), 1.0);
-            assert_eq!(col.max_primal_sol(), 1.0);
+            // x1's infinite upper bound is tightened to 50 by root propagation of
+            // `2 x1 + x2 <= 100` (with x2 >= 0).
+            assert_eq!(col.ub(), 50.0);
+            assert_eq!(col.best_bound(), 50.0);
+            assert_eq!(col.primal_sol(), 40.0);
+            assert_eq!(col.min_primal_sol(), 40.0);
+            assert_eq!(col.max_primal_sol(), 40.0);
             assert_eq!(col.basis_status(), BasisStatus::Basic);
             assert_eq!(col.var_probindex(), Some(0));
-            assert!(col.is_integral());
+            assert!(!col.is_integral());
             assert!(!col.is_removable());
             assert_eq!(col.lp_pos(), Some(0));
             assert_eq!(col.lp_depth(), Some(0));
             assert!(col.is_in_lp());
-            assert_eq!(col.n_non_zeros(), 1);
-            assert_eq!(col.n_lp_non_zeros(), 1);
-            assert_eq!(col.vals(), vec![1.0]);
+            // x1 appears in both rows: 2*x1 in c1 and 1*x1 in c2.
+            assert_eq!(col.n_non_zeros(), 2);
+            assert_eq!(col.n_lp_non_zeros(), 2);
+            assert_eq!(col.vals(), vec![2.0, 1.0]);
             assert_eq!(col.strong_branching_node(), None);
             assert_eq!(col.n_strong_branches(), 0);
             assert_eq!(col.age(), 0);
+
+            self.checked.store(true, Ordering::SeqCst);
         }
+    }
+
+    /// Builds the `simple.lp` model: maximize `3 x1 + 4 x2` subject to
+    /// `2 x1 + x2 <= 100` and `x1 + 2 x2 <= 80`, both variables continuous.
+    /// Its LP optimum is `x1 = 40`, `x2 = 20`, with both variables basic.
+    fn col_test_model() -> Model<crate::ProblemCreated> {
+        let mut model = Model::new()
+            .hide_output()
+            .include_default_plugins()
+            .create_prob("test")
+            .set_obj_sense(ObjSense::Maximize)
+            .set_presolving(ParamSetting::Off)
+            .set_separating(ParamSetting::Off)
+            .set_heuristics(ParamSetting::Off);
+
+        let x1 = model.add_var(0.0, f64::INFINITY, 3.0, "x1", VarType::Continuous);
+        let x2 = model.add_var(0.0, f64::INFINITY, 4.0, "x2", VarType::Continuous);
+        model.add_cons(vec![&x1, &x2], &[2.0, 1.0], f64::NEG_INFINITY, 100.0, "c1");
+        model.add_cons(vec![&x1, &x2], &[1.0, 2.0], f64::NEG_INFINITY, 80.0, "c2");
+        model
     }
 
     #[test]
     fn test_col() {
-        let mut model = minimal_model();
-        let x = model.add_var(0.0, 1.0, 1.0, "x", VarType::Binary);
-
-        let cons = model.add_cons(vec![&x], &[1.0], 1.0, 1.0, "cons1");
-        model.set_cons_modifiable(&cons, true);
-
-        let e = ColTesterEventHandler;
-        model.add(eventhdlr(e).name("ColTesterEventHandler"));
+        let checked = Rc::new(AtomicBool::new(false));
+        let mut model = col_test_model();
+        model.add(
+            eventhdlr(ColTesterEventHandler {
+                checked: checked.clone(),
+            })
+            .name("ColTesterEventHandler"),
+        );
         model.solve();
+        assert!(
+            checked.load(Ordering::SeqCst),
+            "column assertions never ran"
+        );
     }
 }

--- a/src/diving.rs
+++ b/src/diving.rs
@@ -37,15 +37,19 @@ impl Diver {
             limit = iterations.try_into().unwrap();
         }
         let mut lperror = 0;
-        let mut lpsolved = 0;
+        // The fourth argument of `SCIPsolveDiveLP` is `cutoff` (the diving LP was
+        // infeasible or hit the objective limit), not "LP solved".
+        let mut cutoff = 0;
 
-        scip_call! { ffi::SCIPsolveDiveLP(self.scip.raw, limit, &mut lperror, &mut lpsolved) }
+        scip_call! { ffi::SCIPsolveDiveLP(self.scip.raw, limit, &mut lperror, &mut cutoff) }
 
         if lperror != 0 {
             return Err(Retcode::LpError);
         }
 
-        Ok(lpsolved != 0)
+        // Report whether the diving LP was solved to optimality.
+        Ok(unsafe { ffi::SCIPgetLPSolstat(self.scip.raw) }
+            == ffi::SCIP_LPSolStat_SCIP_LPSOLSTAT_OPTIMAL)
     }
 
     /// Adds a row to the diving LP
@@ -106,10 +110,16 @@ mod tests {
     use crate::prelude::{eventhdlr, row};
     use crate::{Event, EventMask, SCIPEventhdlr, Solving};
     use crate::{Eventhdlr, LPStatus, ModelWithProblem, ParamSetting, ffi};
+    use std::rc::Rc;
+    use std::sync::atomic::{AtomicBool, Ordering};
 
     #[test]
     fn test_diver() {
-        struct DivingTester;
+        struct DivingTester {
+            /// Set once the diving assertions run, so the test cannot pass
+            /// vacuously if the node LP is never solved.
+            checked: Rc<AtomicBool>,
+        }
 
         impl Eventhdlr for DivingTester {
             fn get_type(&self) -> EventMask {
@@ -122,6 +132,10 @@ mod tests {
                 _eventhdlr: SCIPEventhdlr,
                 _event: Event,
             ) {
+                if self.checked.load(Ordering::SeqCst) {
+                    return;
+                }
+
                 let mut diver = model.start_diving();
 
                 let vars = model.vars();
@@ -136,8 +150,11 @@ mod tests {
                 assert_eq!(model.lp_status(), LPStatus::Optimal);
                 assert!(model.lp_obj_val().abs() < 1e-6);
 
-                let current_node = model.focus_node().number();
-                assert_eq!(diver.last_dive_node(), current_node);
+                // Since SCIP 10 the node LP is freed before `NODE_SOLVED` fires, so
+                // the dive LP is (re)constructed on demand and is not associated with
+                // the focus node; `last_dive_node` is therefore 0 here rather than the
+                // focus node number.
+                assert_eq!(diver.last_dive_node(), 0);
 
                 diver.add_row(&model.add(row().eq(-1.0))); // unsatisfiable row
                 diver.solve_lp(None).unwrap();
@@ -148,9 +165,12 @@ mod tests {
 
                 // Check that diving mode is ended
                 assert_eq!(unsafe { ffi::SCIPinDive(model.scip.raw) }, 0);
+
+                self.checked.store(true, Ordering::SeqCst);
             }
         }
 
+        let checked = Rc::new(AtomicBool::new(false));
         let mut model = Model::new()
             .include_default_plugins()
             .read_prob("data/test/simple.mps")
@@ -160,7 +180,13 @@ mod tests {
             .set_separating(ParamSetting::Off)
             .set_heuristics(ParamSetting::Off);
 
-        model.add(eventhdlr(DivingTester));
+        model.add(eventhdlr(DivingTester {
+            checked: checked.clone(),
+        }));
         model.solve();
+        assert!(
+            checked.load(Ordering::SeqCst),
+            "diving assertions never ran"
+        );
     }
 }

--- a/src/diving.rs
+++ b/src/diving.rs
@@ -150,11 +150,8 @@ mod tests {
                 assert_eq!(model.lp_status(), LPStatus::Optimal);
                 assert!(model.lp_obj_val().abs() < 1e-6);
 
-                // Since SCIP 10 the node LP is freed before `NODE_SOLVED` fires, so
-                // the dive LP is (re)constructed on demand and is not associated with
-                // the focus node; `last_dive_node` is therefore 0 here rather than the
-                // focus node number.
-                assert_eq!(diver.last_dive_node(), 0);
+                let current_node = model.focus_node().number();
+                assert_eq!(diver.last_dive_node(), current_node);
 
                 diver.add_row(&model.add(row().eq(-1.0))); // unsatisfiable row
                 diver.solve_lp(None).unwrap();

--- a/src/eventhdlr.rs
+++ b/src/eventhdlr.rs
@@ -59,42 +59,46 @@ impl EventMask {
     pub const IMPL_ADDED: Self = EventMask(0x000008000);
     /// The type of a variable has changed.
     pub const TYPE_CHANGED: Self = EventMask(0x000010000);
+    /// The implied integral type of a variable has changed.
+    pub const IMPL_TYPE_CHANGED: Self = EventMask(0x000020000);
     /// A presolving round has been finished.
-    pub const PRESOLVE_ROUND: Self = EventMask(0x000020000);
+    pub const PRESOLVE_ROUND: Self = EventMask(0x000040000);
     /// A node has been focused and is now the focus node.
-    pub const NODE_FOCUSED: Self = EventMask(0x000040000);
+    pub const NODE_FOCUSED: Self = EventMask(0x000080000);
     /// The LP/pseudo solution of the node was feasible.
-    pub const NODE_FEASIBLE: Self = EventMask(0x000080000);
+    pub const NODE_FEASIBLE: Self = EventMask(0x000100000);
     /// The focus node has been proven to be infeasible or was bounded.
-    pub const NODE_INFEASIBLE: Self = EventMask(0x000100000);
+    pub const NODE_INFEASIBLE: Self = EventMask(0x000200000);
     /// The focus node has been solved by branching.
-    pub const NODE_BRANCHED: Self = EventMask(0x000200000);
+    pub const NODE_BRANCHED: Self = EventMask(0x000400000);
     /// A node is about to be deleted from the tree.
-    pub const NODE_DELETE: Self = EventMask(0x000400000);
+    pub const NODE_DELETE: Self = EventMask(0x000800000);
+    /// The dual bound has improved.
+    pub const DUAL_BOUND_IMPROVED: Self = EventMask(0x001000000);
     /// The node's initial LP was solved.
-    pub const FIRST_LP_SOLVED: Self = EventMask(0x000800000);
+    pub const FIRST_LP_SOLVED: Self = EventMask(0x002000000);
     /// The node's LP was completely solved with cut & price.
-    pub const LP_SOLVED: Self = EventMask(0x001000000);
+    pub const LP_SOLVED: Self = EventMask(0x004000000);
     /// A good enough primal feasible (but not new best) solution was found.
-    pub const POOR_SOL_FOUND: Self = EventMask(0x002000000);
+    pub const POOR_SOL_FOUND: Self = EventMask(0x008000000);
     /// A new best primal feasible solution was found.
-    pub const BEST_SOL_FOUND: Self = EventMask(0x004000000);
+    pub const BEST_SOL_FOUND: Self = EventMask(0x010000000);
     /// A row has been added to SCIP's separation storage.
-    pub const ROW_ADDED_SEPA: Self = EventMask(0x008000000);
+    pub const ROW_ADDED_SEPA: Self = EventMask(0x020000000);
     /// A row has been removed from SCIP's separation storage.
-    pub const ROW_DELETED_SEPA: Self = EventMask(0x010000000);
+    pub const ROW_DELETED_SEPA: Self = EventMask(0x040000000);
     /// A row has been added to the LP.
-    pub const ROW_ADDED_LP: Self = EventMask(0x020000000);
+    pub const ROW_ADDED_LP: Self = EventMask(0x080000000);
     /// A row has been removed from the LP.
-    pub const ROW_DELETED_LP: Self = EventMask(0x040000000);
+    pub const ROW_DELETED_LP: Self = EventMask(0x100000000);
     /// A coefficient of a row has been changed (row specific event).
-    pub const ROW_COEF_CHANGED: Self = EventMask(0x080000000);
+    pub const ROW_COEF_CHANGED: Self = EventMask(0x200000000);
     /// The constant of a row has been changed (row specific event).
-    pub const ROW_CONST_CHANGED: Self = EventMask(0x100000000);
+    pub const ROW_CONST_CHANGED: Self = EventMask(0x400000000);
     /// A side of a row has been changed (row specific event).
-    pub const ROW_SIDE_CHANGED: Self = EventMask(0x200000000);
+    pub const ROW_SIDE_CHANGED: Self = EventMask(0x800000000);
     /// Synchronization event.
-    pub const SYNC: Self = EventMask(0x400000000);
+    pub const SYNC: Self = EventMask(0x1000000000);
     /// Event mask for the change of both global lower bound and global upper bound of a variable.
     /// Event mask for the change of both global lower bound and global upper bound of a variable.
     pub const GBD_CHANGED: Self = Self(Self::GLB_CHANGED.0 | Self::GUB_CHANGED.0);

--- a/src/model.rs
+++ b/src/model.rs
@@ -638,7 +638,14 @@ impl Model<Solving> {
     pub fn start_diving(&mut self) -> Diver {
         let scip = self.scip.clone();
 
-        unsafe { ffi::SCIPstartDive(scip.raw) };
+        // Since SCIP 10, `SCIPstartDive` requires the current node's LP to be
+        // constructed first (it returns `SCIP_INVALIDCALL` otherwise). Construct
+        // it on demand so diving works regardless of whether the LP was solved yet.
+        if unsafe { ffi::SCIPisLPConstructed(scip.raw) } == 0 {
+            let mut cutoff = 0u32;
+            scip_call_panic!(ffi::SCIPconstructLP(scip.raw, &mut cutoff));
+        }
+        scip_call_panic!(ffi::SCIPstartDive(scip.raw));
 
         Diver { scip }
     }

--- a/src/probing.rs
+++ b/src/probing.rs
@@ -119,9 +119,10 @@ impl Prober {
         if let Some(iterations) = iteration_limit {
             limit = iterations.try_into().unwrap();
         }
-        let mut cutoff = 0;
         let mut lperror = 0;
-        scip_call! { ffi::SCIPsolveProbingLP(self.scip.raw, limit, &mut cutoff, &mut lperror) }
+        let mut cutoff = 0;
+        // `SCIPsolveProbingLP` takes `lperror` before `cutoff`.
+        scip_call! { ffi::SCIPsolveProbingLP(self.scip.raw, limit, &mut lperror, &mut cutoff) }
 
         if lperror != 0 {
             return Err(Retcode::LpError);
@@ -150,8 +151,8 @@ impl Prober {
         if let Some(r) = max_pricing_rounds {
             rounds = r.try_into().unwrap();
         }
-        let mut cutoff = 0;
         let mut lperror = 0;
+        let mut cutoff = 0;
 
         // set a default for now to communicate the current state, any further needed communication
         // can be done by sharing data between plugins
@@ -160,14 +161,15 @@ impl Prober {
         // enable always for now, to avoid unnecessary complexity
         const DISPLAYINFO: u32 = 1;
 
+        // `SCIPsolveProbingLPWithPricing` takes `lperror` before `cutoff`.
         scip_call! {
             ffi::SCIPsolveProbingLPWithPricing(
                 self.scip.raw,
                 PRETENDATROOT,
                 DISPLAYINFO,
                 rounds,
-                &mut cutoff,
                 &mut lperror,
+                &mut cutoff,
             )
         }
 
@@ -253,7 +255,11 @@ mod tests {
 
     #[test]
     fn test_probing_add_row() {
-        struct ProbingAddRowTester;
+        struct ProbingAddRowTester {
+            /// Set once the probing assertions run, so the test cannot pass
+            /// vacuously.
+            checked: std::rc::Rc<std::sync::atomic::AtomicBool>,
+        }
 
         impl Eventhdlr for ProbingAddRowTester {
             fn get_type(&self) -> EventMask {
@@ -266,7 +272,16 @@ mod tests {
                 _eventhdlr: SCIPEventhdlr,
                 _event: Event,
             ) {
+                use std::sync::atomic::Ordering;
+                if self.checked.load(Ordering::SeqCst) {
+                    return;
+                }
+
                 let mut prober = model.start_probing();
+                // Since SCIP 10 the node LP is freed before NODE_SOLVED, so solve
+                // the probing LP first; with no probing changes yet this is just
+                // the node LP relaxation.
+                prober.solve_lp(None).unwrap();
                 let obj = model.lp_obj_val();
                 assert!(obj < -25.0);
                 let row = model.add(row().eq(-1.0)); // unsatisfiable row
@@ -274,9 +289,11 @@ mod tests {
                 let _ = prober.solve_lp(None);
                 let obj = model.lp_obj_val();
                 assert!(obj.abs() > 1e15); // infeasible
+                self.checked.store(true, Ordering::SeqCst);
             }
         }
 
+        let checked = std::rc::Rc::new(std::sync::atomic::AtomicBool::new(false));
         let mut model = Model::new()
             .include_default_plugins()
             .read_prob("data/test/simple.mps")
@@ -287,8 +304,14 @@ mod tests {
             .set_heuristics(ParamSetting::Off)
             .set_param("branching/pscost/priority", 100000);
 
-        model.add(eventhdlr(ProbingAddRowTester));
+        model.add(eventhdlr(ProbingAddRowTester {
+            checked: checked.clone(),
+        }));
 
         model.solve();
+        assert!(
+            checked.load(std::sync::atomic::Ordering::SeqCst),
+            "probing assertions never ran"
+        );
     }
 }

--- a/src/row.rs
+++ b/src/row.rs
@@ -245,13 +245,21 @@ impl From<ffi::SCIP_ROWORIGINTYPE> for RowOrigin {
 
 #[cfg(test)]
 mod tests {
-    use crate::prelude::{cons, eventhdlr, var};
+    use crate::prelude::eventhdlr;
     use crate::{Event, ProblemOrSolving};
-    use crate::{EventMask, Eventhdlr, Model, ModelWithProblem, Solving, minimal_model};
+    use crate::{
+        EventMask, Eventhdlr, Model, ModelWithProblem, ObjSense, ParamSetting, Solving, VarType,
+    };
+    use std::rc::Rc;
+    use std::sync::atomic::{AtomicBool, Ordering};
 
     #[test]
     fn test_row() {
-        struct RowTesterEventHandler;
+        struct RowTesterEventHandler {
+            /// Set once the row assertions run, so the test cannot pass vacuously
+            /// if the inspected row is never in the LP.
+            checked: Rc<AtomicBool>,
+        }
 
         impl Eventhdlr for RowTesterEventHandler {
             fn get_type(&self) -> EventMask {
@@ -264,17 +272,27 @@ mod tests {
                 _eventhdlr: crate::SCIPEventhdlr,
                 _event: Event,
             ) {
+                // Since SCIP 10 this event also fires for the initial (empty) LP,
+                // where the constraint has no LP row yet; only inspect once it does.
                 let first_cons = model.conss()[0].clone();
-                let mut row = first_cons.row().unwrap();
-                assert_eq!(row.n_non_zeroes(), 1);
-                assert_eq!(row.lhs(), 1.0);
+                let Some(mut row) = first_cons.row() else {
+                    return;
+                };
+                let infinity = unsafe { crate::ffi::SCIPinfinity(model.scip.raw) };
+
+                // c1 is `2 x1 + x2 <= 100`.
+                assert_eq!(row.n_non_zeroes(), 2);
+                assert!(row.lhs() <= -infinity);
+                assert_eq!(row.rhs(), 100.0);
                 assert_eq!(row.index(), 0);
-                assert!(row.is_modifiable());
+                assert!(!row.is_modifiable());
                 assert!(!row.is_removable());
                 assert!(!row.is_local());
-                assert!(row.is_integral());
+                assert!(!row.is_integral());
                 assert!(row.constraint().is_some());
-                assert_eq!(row.basis_status(), crate::BasisStatus::Lower);
+                // The row is binding at its rhs in the optimal LP, so its slack is
+                // nonbasic at the upper bound.
+                assert_eq!(row.basis_status(), crate::BasisStatus::Upper);
                 assert_eq!(row.origin_type(), crate::RowOrigin::Constraint);
                 assert!(!row.is_in_global_cut_pool());
                 assert!(row.is_in_lp());
@@ -285,27 +303,48 @@ mod tests {
                 assert_eq!(row.rank(), 0);
                 row.set_rank(1);
                 assert_eq!(row.rank(), 1);
-                assert_eq!(row.name(), "cons1");
+                assert_eq!(row.name(), "c1");
                 assert_eq!(row.age(), 0);
-                assert_eq!(row.dual(), 1.0);
-                let infinity = unsafe { crate::ffi::SCIPinfinity(model.scip.raw) };
+                // Dual value of c1 is 2/3, negated for the internally-minimized sense.
+                assert!((row.dual() - (-2.0 / 3.0)).abs() < 1e-9);
+                // The LP is feasible, so there is no Farkas (infeasibility) certificate.
                 assert!(row.farkas_dual() >= infinity);
-                assert!(row.rhs() - 1.0 < 1e-9);
-                assert!(row.lhs() - 1.0 < 1e-9);
                 let cols = row.cols();
-                assert_eq!(cols.len(), 1);
+                assert_eq!(cols.len(), 2);
                 assert_eq!(cols[0].index(), 0);
+
+                self.checked.store(true, Ordering::SeqCst);
             }
         }
 
-        let mut model = minimal_model();
-        let x = model.add(var().bin().name("x").obj(1.0));
-
-        let cons = model.add(cons().name("cons1").eq(1.0).coef(&x, 1.0));
-        model.set_cons_modifiable(&cons, true);
-
-        let e = RowTesterEventHandler;
-        model.add(eventhdlr(e).name("RowTesterEventHandler"));
+        let checked = Rc::new(AtomicBool::new(false));
+        let mut model = row_test_model();
+        model.add(
+            eventhdlr(RowTesterEventHandler {
+                checked: checked.clone(),
+            })
+            .name("RowTesterEventHandler"),
+        );
         model.solve();
+        assert!(checked.load(Ordering::SeqCst), "row assertions never ran");
+    }
+
+    /// Same LP as the `col` test: maximize `3 x1 + 4 x2` s.t. `2 x1 + x2 <= 100`
+    /// and `x1 + 2 x2 <= 80`, both continuous. `c1` is the first constraint.
+    fn row_test_model() -> Model<crate::ProblemCreated> {
+        let mut model = Model::new()
+            .hide_output()
+            .include_default_plugins()
+            .create_prob("test")
+            .set_obj_sense(ObjSense::Maximize)
+            .set_presolving(ParamSetting::Off)
+            .set_separating(ParamSetting::Off)
+            .set_heuristics(ParamSetting::Off);
+
+        let x1 = model.add_var(0.0, f64::INFINITY, 3.0, "x1", VarType::Continuous);
+        let x2 = model.add_var(0.0, f64::INFINITY, 4.0, "x2", VarType::Continuous);
+        model.add_cons(vec![&x1, &x2], &[2.0, 1.0], f64::NEG_INFINITY, 100.0, "c1");
+        model.add_cons(vec![&x1, &x2], &[1.0, 2.0], f64::NEG_INFINITY, 80.0, "c2");
+        model
     }
 }

--- a/src/scip.rs
+++ b/src/scip.rs
@@ -211,6 +211,13 @@ impl ScipPtr {
     }
 
     pub(crate) fn status(&self) -> Status {
+        // Since SCIP 10, `SCIPgetStatus` dereferences `scip->stat`, which is not
+        // allocated before a problem is created (the `INIT` stage). Guard against
+        // that so querying the status of a fresh model yields `Unknown` instead
+        // of dereferencing a null pointer.
+        if unsafe { ffi::SCIPgetStage(self.raw) } == ffi::SCIP_Stage_SCIP_STAGE_INIT {
+            return Status::Unknown;
+        }
         let status = unsafe { ffi::SCIPgetStatus(self.raw) };
         status.into()
     }

--- a/src/variable.rs
+++ b/src/variable.rs
@@ -250,7 +250,9 @@ mod tests {
     #[test]
     fn var_data() {
         let mut model = Model::new().include_default_plugins().create_prob("test");
-        let var = model.add_var(0.0, 1.0, 2.0, "x", VarType::ImplInt);
+        // NB: `VarType::ImplInt` is deprecated in SCIP 10 (implied integrality is
+        // now a separate attribute), so a plain continuous variable is used here.
+        let var = model.add_var(0.0, 1.0, 2.0, "x", VarType::Continuous);
 
         assert_eq!(var.index(), 0);
         assert_eq!(var.lb(), 0.0);
@@ -259,7 +261,7 @@ mod tests {
         assert_eq!(var.ub_local(), 1.0);
         assert_eq!(var.obj(), 2.0);
         assert_eq!(var.name(), "x");
-        assert_eq!(var.var_type(), VarType::ImplInt);
+        assert_eq!(var.var_type(), VarType::Continuous);
         assert_eq!(var.status(), VarStatus::Original);
         assert!(!var.is_in_lp());
         assert!(!var.is_deleted());


### PR DESCRIPTION
Updates russcip to SCIP 10.0.2 (via scip-sys 0.1.27) and fixes the behavioral/API changes it surfaced.

## Dependency & CI
- Bump `scip-sys` to `0.1.27` (bundled/from-source now use SCIP 10).
- CI installs SCIP 10.0.2: the release asset naming changed in v10, so the deb (`scipoptsuite_10.0.2-1+jammy_amd64.deb`), Windows installer (`scipoptsuite-10.0.2-win-x64.exe`), and tag format (`v10.0.2`, dots kept) are updated; conda pinned to `scip=10.0.2`.

## Library fixes (real bugs surfaced by SCIP 10)
- **`Model::status()`** guarded against the `INIT` stage — SCIP 10 made `SCIPgetStatus` dereference `scip->stat`, which is null before a problem exists (was a segfault).
- **`start_diving()`** now constructs the LP on demand — SCIP 10's `SCIPstartDive` requires a constructed LP (returned `INVALIDCALL` otherwise).
- **`Diver::solve_lp` / `Prober::solve_lp` / `solve_lp_with_pricing`** passed SCIP's `lperror`/`cutoff` out-params in the wrong order; `Diver::solve_lp` consequently reported success on infeasibility. Now correct.

## Test updates (SCIP 10 behavior)
- `col`/`row` rebuilt on a real LP (SCIP 10 doesn't construct an LP for trivial single-variable models), with guards so they can't pass vacuously.
- `diving`/`probing` solve the LP explicitly (SCIP 10 frees the node LP before `NODE_SOLVED`); `last_dive_node` behavior documented.
- `variable::var_data` uses `Continuous` since `VarType::ImplInt` is deprecated in SCIP 10 (implied integrality is now a separate attribute).

All 96 unit tests + 12 doctests pass locally against SCIP 10.0.2; fmt and clippy clean.