### PR TITLE
Drop libclang build dependency in bundled mode

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -85,8 +85,35 @@ jobs:
       - uses: actions/checkout@v3
       - name: Test
         run: |
-          cargo test --features bundled
-          cargo test --features bundled --examples
+          cargo test --no-default-features --features bundled,datastore
+          cargo test --no-default-features --features bundled,datastore --examples
+
+  # Builds the bundled feature in a minimal image that has no libclang, proving
+  # `--no-default-features --features bundled` needs neither a SCIP installation
+  # nor bindgen/libclang. Guards against accidentally pulling bindgen back into
+  # the bundled path.
+  linux-bundled-no-clang:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    container: rust:slim-bookworm
+    steps:
+      - name: Install checkout prerequisites
+        run: apt-get update && apt-get install -y --no-install-recommends git ca-certificates
+      - uses: actions/checkout@v3
+      - name: Ensure libclang is unavailable
+        run: |
+          if ldconfig -p | grep -iq libclang || command -v clang >/dev/null 2>&1; then
+            echo "libclang/clang unexpectedly present in this image" >&2
+            exit 1
+          fi
+      - name: Assert bindgen is not in the bundled dependency tree
+        run: |
+          if cargo tree --no-default-features --features bundled,datastore -i bindgen >/dev/null 2>&1; then
+            echo "bindgen leaked into the bundled dependency tree" >&2
+            exit 1
+          fi
+      - name: Build bundled (lib, tests and examples) without libclang
+        run: cargo build --no-default-features --features bundled,datastore --all-targets
 
 
   windows-test:
@@ -155,6 +182,7 @@ jobs:
       - test-with-coverage
       - windows-test
       - linux-bundled-test
+      - linux-bundled-no-clang
       - cargo-fmt-check
       - cargo-clippy
       - semver-check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,13 +9,18 @@ edition = "2024"
 exclude = ["data/test/*"]
 
 [features]
-default = ["datastore"]
+default = ["datastore", "bindgen"]
+# Generate SCIP bindings at build time with bindgen (requires libclang). Needed
+# for the system/SCIPOPTDIR/conda paths where the SCIP ABI isn't known ahead of
+# time. The `bundled` path ships prebuilt bindings, so a libclang-free build is
+# `--no-default-features --features bundled`.
+bindgen = ["scip-sys/bindgen"]
 bundled = ["scip-sys/bundled"]
 from-source = ["scip-sys/from-source"]
 datastore = ["anymap3"]
 
 [dependencies]
-scip-sys = "0.1.27"
+scip-sys = { version = "0.1.28", default-features = false }
 anymap3 = { version = "1.0.1", optional = true }
 
 [dev-dependencies]

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -3,11 +3,18 @@
 By running
 
 ```bash
-cargo add russcip --features bundled
+cargo add russcip --no-default-features --features bundled
 ```
 
 The `bundled` feature will download a precompiled SCIP as part of the build process.
-This is the easiest to get started with russcip.
+It also ships prebuilt bindings, so this build requires neither a SCIP installation
+nor `libclang` (bindgen). This is the easiest way to get started with russcip.
+
+If you also use the `datastore`, re-enable it explicitly:
+
+```bash
+cargo add russcip --no-default-features --features bundled,datastore
+```
 
 ### Custom SCIP installation
 

--- a/README.md
+++ b/README.md
@@ -25,8 +25,7 @@ The easiest way is to run this in your crate directory
 cargo add russcip --no-default-features --features bundled
 ```
 The `bundled` feature ships prebuilt bindings, so this build needs neither a SCIP
-installation nor `libclang`. (Add the datastore back with
-`--no-default-features --features bundled,datastore` if you need it.)
+installation nor `libclang`.
 For other installation methods, please check [INSTALL.md](INSTALL.md).
 
 ### Usage

--- a/README.md
+++ b/README.md
@@ -22,9 +22,12 @@ The project is currently actively developed, issues/pull-requests are very welco
 ### Installation
 The easiest way is to run this in your crate directory
 ```bash
-cargo add russcip --features bundled
+cargo add russcip --no-default-features --features bundled
 ```
-for other installation methods, please check [INSTALL.md](INSTALL.md).
+The `bundled` feature ships prebuilt bindings, so this build needs neither a SCIP
+installation nor `libclang`. (Add the datastore back with
+`--no-default-features --features bundled,datastore` if you need it.)
+For other installation methods, please check [INSTALL.md](INSTALL.md).
 
 ### Usage
 


### PR DESCRIPTION
Builds on scip-sys 0.1.28, which makes `bindgen` (and the `libclang` it needs) an opt-out feature and ships prebuilt bindings for the `bundled` path.

## Changes
- Bump `scip-sys` to `0.1.28` and depend on it with `default-features = false`.
- Add a russcip `bindgen` feature forwarding to `scip-sys/bindgen`, kept in `default` so the system / `SCIPOPTDIR` / conda paths keep working out of the box (those need bindgen because the SCIP ABI isn't known ahead of time).
- `bundled = ["scip-sys/bundled"]` no longer pulls bindgen. A `--no-default-features --features bundled` build therefore needs **neither a SCIP installation nor libclang**, and compiles noticeably faster.
- Updated README / INSTALL to the `--no-default-features --features bundled` invocation (and how to re-add `datastore`).
- CI: the existing `linux-bundled-test` now uses `--no-default-features --features bundled,datastore`; added a **`linux-bundled-no-clang`** job that builds the bundled feature in a `rust:slim-bookworm` container with no libclang. It asserts libclang is absent and that bindgen is not in the dependency tree, guarding against accidentally pulling bindgen back into the bundled path.

## Verification (local)
- Default build (`cargo build`): bindgen present, builds against system SCIP — unchanged behaviour.
- `cargo tree --no-default-features --features bundled,datastore -i bindgen` → bindgen absent.
- `cargo build --no-default-features --features bundled,datastore --all-targets` → builds without compiling bindgen.
- Test suite passes in bundled mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)