### PR TITLE
Gate bin_packing example behind datastore feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,8 @@ rand = "0.8"
 
 [lints.clippy]
 too_many_arguments = "allow"
+
+# Uses the datastore API, so it only builds when the `datastore` feature is on.
+[[example]]
+name = "bin_packing"
+required-features = ["datastore"]


### PR DESCRIPTION
It uses the datastore API, so building examples without the datastore feature (e.g. `--no-default-features --features bundled`) failed to compile. Mark it with `required-features = ["datastore"]` so Cargo skips it when the feature is off.