### PR TITLE
Add concurrent solve support

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -13,3 +13,4 @@ This directory contains examples of how to use the `russcip` library.
 8. [Node event handler](node_event_handler.rs): An example demonstrating how to track and report information about nodes during the branch-and-bound process.
 9. [Depth-first node selection](depth_first_node_selection.rs): An example showing how to implement a custom node selector that traverses the branch-and-bound tree in depth-first order.
 10. [Bin packing](bin_packing.rs): An example branch-and-price implementation for the bin packing problem, following the guide in https://github.com/mmghannam/co-work2024/blob/main/Day3/README.md
+11. [Concurrent solve](concurrent_solve.rs): An example showing how to solve a model using SCIP's concurrent solvers to leverage multiple CPU cores.

--- a/examples/concurrent_solve.rs
+++ b/examples/concurrent_solve.rs
@@ -1,0 +1,41 @@
+use russcip::prelude::*;
+
+fn main() {
+    // Pass "deterministic" as the first argument to solve in deterministic mode;
+    // anything else (or no argument) uses the default opportunistic mode.
+    let deterministic = std::env::args().nth(1).as_deref() == Some("deterministic");
+
+    // Read the MIPLIB instance p0201.
+    let model = Model::new()
+        .include_default_plugins()
+        .read_prob("data/test/p0201.mps")
+        .unwrap();
+
+    // Use one thread per available CPU core for the concurrent solve. The
+    // `bundled` SCIP library is built with thread support, so this runs several
+    // SCIP solvers in parallel and returns the best result.
+    let n_threads = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1) as i32;
+    let mode = if deterministic { 1 } else { 0 };
+    println!(
+        "Solving with {n_threads} threads in {} mode",
+        if deterministic {
+            "deterministic"
+        } else {
+            "opportunistic"
+        }
+    );
+    let solved_model = model
+        .set_int_param("parallel/maxnthreads", n_threads)
+        .unwrap()
+        .set_int_param("parallel/mode", mode)
+        .unwrap()
+        .solve_concurrent();
+
+    let status = solved_model.status();
+    println!("Solved with status {status:?}");
+
+    let obj_val = solved_model.obj_val();
+    println!("Objective value: {obj_val}");
+}

--- a/src/model.rs
+++ b/src/model.rs
@@ -432,6 +432,43 @@ impl Model<ProblemCreated> {
         self.try_solve()
             .expect("Failed to solve problem in state ProblemCreated")
     }
+
+    /// Tries to solve the model using SCIP's concurrent solvers, leveraging
+    /// multiple CPU cores when the underlying SCIP was built with thread
+    /// support (the `bundled` library is). Returns a new `Model` instance with
+    /// a `Solved` state if successful.
+    ///
+    /// The number of threads can be controlled with the `parallel/maxnthreads`
+    /// parameter, and `parallel/mode` selects between opportunistic
+    /// (nondeterministic, `0`, the default) and deterministic (`1`) solving,
+    /// e.g. `model.set_int_param("parallel/mode", 1)`.
+    ///
+    /// If SCIP was built without thread support this returns a [`Retcode`]
+    /// error; use [`Model::try_solve`] for the sequential solve in that case.
+    #[allow(unused_mut)]
+    pub fn try_solve_concurrent(mut self) -> Result<Model<Solved>, Retcode> {
+        self.scip.solve_concurrent()?;
+
+        Ok(Model {
+            scip: self.scip,
+            state: PhantomData,
+        })
+    }
+
+    /// Solves the model using SCIP's concurrent solvers and returns a new
+    /// `Model` instance with a `Solved` state.
+    ///
+    /// See [`Model::try_solve_concurrent`] for details and requirements.
+    ///
+    /// # Panics
+    ///
+    /// This method panics if the problem cannot be solved concurrently in the
+    /// current state (e.g. SCIP was built without thread support).
+    #[allow(unused_mut)]
+    pub fn solve_concurrent(mut self) -> Model<Solved> {
+        self.try_solve_concurrent()
+            .expect("Failed to solve problem concurrently in state ProblemCreated")
+    }
 }
 
 impl Model<Solving> {
@@ -2151,6 +2188,16 @@ mod tests {
     fn try_solve_on_valid_model() {
         let solved = create_model().try_solve().unwrap();
         assert_eq!(solved.status(), Status::Optimal);
+    }
+
+    #[test]
+    fn solve_concurrent_on_valid_model() {
+        let solved = create_model()
+            .set_int_param("parallel/maxnthreads", 2)
+            .unwrap()
+            .solve_concurrent();
+        assert_eq!(solved.status(), Status::Optimal);
+        assert_eq!(solved.obj_val(), 200.);
     }
 
     #[test]

--- a/src/scip.rs
+++ b/src/scip.rs
@@ -324,6 +324,11 @@ impl ScipPtr {
         Ok(())
     }
 
+    pub(crate) fn solve_concurrent(&self) -> Result<(), Retcode> {
+        scip_call!(ffi::SCIPsolveConcurrent(self.raw));
+        Ok(())
+    }
+
     pub(crate) fn n_sols(&self) -> usize {
         unsafe { ffi::SCIPgetNSols(self.raw) as usize }
     }


### PR DESCRIPTION
Adds `Model::solve_concurrent` / `try_solve_concurrent`, which call SCIP's `SCIPsolveConcurrent` to run several SCIP solvers in parallel across CPU cores. The bundled SCIP library is built with thread support, so this works out of the box; thread count is set via `parallel/maxnthreads` and `parallel/mode` selects opportunistic vs deterministic solving. Includes a test and a `concurrent_solve` example (solves p0201, with a CLI flag to pick the mode). Closes #43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)