### PR TITLE
Add JSON statistics output (SCIP 10)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,14 @@ bindgen = ["scip-sys/bindgen"]
 bundled = ["scip-sys/bundled"]
 from-source = ["scip-sys/from-source"]
 datastore = ["anymap3"]
+# Enables serde-based helpers, e.g. parsing the statistics JSON into a
+# `serde_json::Value`.
+serde = ["dep:serde_json"]
 
 [dependencies]
 scip-sys = { version = "0.1.28", default-features = false }
 anymap3 = { version = "1.0.1", optional = true }
+serde_json = { version = "1.0", optional = true }
 
 [dev-dependencies]
 rayon = "1.5.1"

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ A safe Rust interface for [SCIP](https://www.scipopt.org/index.php#download). Th
 SCIP's C-API through the `ffi` module.
 The project is currently actively developed, issues/pull-requests are very welcome.
 
+russcip is currently compatible with **SCIP 10.0.2**, which is what the `bundled` feature ships. Linking against
+older SCIP versions may work but is not guaranteed and is not supported.
+
 ### Installation
 The easiest way is to run this in your crate directory
 ```bash

--- a/src/model.rs
+++ b/src/model.rs
@@ -1667,6 +1667,24 @@ pub trait WithSolvingStats {
 
     /// Returns the number of LP iterations performed by the optimization model.
     fn n_lp_iterations(&self) -> usize;
+
+    /// Returns the solving statistics in JSON format.
+    ///
+    /// This wraps SCIP's `SCIPprintStatisticsJson`, available since SCIP 10.
+    fn stats_json(&self) -> String;
+
+    /// Writes the solving statistics in JSON format directly to `path`.
+    ///
+    /// Unlike [`stats_json`](Self::stats_json), this streams the output to the
+    /// file without buffering it in memory, mirroring SCIP's native
+    /// `SCIPprintStatisticsJson` behaviour.
+    fn write_stats_json(&self, path: &str) -> Result<(), Retcode>;
+
+    /// Returns the solving statistics parsed as a [`serde_json::Value`].
+    ///
+    /// Requires the `serde` feature.
+    #[cfg(feature = "serde")]
+    fn stats_json_value(&self) -> serde_json::Value;
 }
 
 trait ModelStageWithSolvingStats {}
@@ -1698,6 +1716,24 @@ impl<S: ModelStageWithSolvingStats> WithSolvingStats for Model<S> {
     /// Returns the number of LP iterations performed by the optimization model.
     fn n_lp_iterations(&self) -> usize {
         self.scip.n_lp_iterations()
+    }
+
+    /// Returns the solving statistics in JSON format.
+    fn stats_json(&self) -> String {
+        self.scip
+            .statistics_json()
+            .expect("Failed to get statistics in JSON format")
+    }
+
+    /// Writes the solving statistics in JSON format directly to `path`.
+    fn write_stats_json(&self, path: &str) -> Result<(), Retcode> {
+        self.scip.write_statistics_json(path)
+    }
+
+    /// Returns the solving statistics parsed as a [`serde_json::Value`].
+    #[cfg(feature = "serde")]
+    fn stats_json_value(&self) -> serde_json::Value {
+        serde_json::from_str(&self.stats_json()).expect("SCIP produced invalid statistics JSON")
     }
 }
 
@@ -2242,6 +2278,36 @@ mod tests {
             .solve_concurrent();
         assert_eq!(solved.status(), Status::Optimal);
         assert_eq!(solved.obj_val(), 200.);
+    }
+
+    #[test]
+    fn stats_json_after_solve() {
+        let solved = create_model().solve();
+        let json = solved.stats_json();
+        // Looks like a JSON object and carries the optimal status.
+        assert!(json.trim_start().starts_with('{'));
+        assert!(json.contains("optimal solution found"));
+    }
+
+    #[test]
+    fn write_stats_json_after_solve() {
+        let solved = create_model().solve();
+        let path = std::env::temp_dir().join("russcip_stats_test.json");
+        let path_str = path.to_str().unwrap();
+        solved.write_stats_json(path_str).unwrap();
+
+        let from_file = std::fs::read_to_string(&path).unwrap();
+        assert!(from_file.trim_start().starts_with('{'));
+        assert!(from_file.contains("optimal solution found"));
+        std::fs::remove_file(&path).unwrap();
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn stats_json_value_after_solve() {
+        let solved = create_model().solve();
+        let stats = solved.stats_json_value();
+        assert_eq!(stats["status"]["status"], "optimal solution found");
     }
 
     #[test]

--- a/src/scip.rs
+++ b/src/scip.rs
@@ -286,6 +286,65 @@ impl ScipPtr {
         Ok(())
     }
 
+    /// Returns the solving statistics in JSON format (`SCIPprintStatisticsJson`,
+    /// available since SCIP 10). SCIP writes to a `FILE*`, so we capture the
+    /// output through a temporary file and read it back into a `String`.
+    pub(crate) fn statistics_json(&self) -> Result<String, Retcode> {
+        unsafe {
+            let file = ffi::tmpfile();
+            if file.is_null() {
+                return Err(Retcode::FileCreateError);
+            }
+
+            let retcode = Retcode::from(ffi::SCIPprintStatisticsJson(self.raw, file));
+            if retcode != Retcode::Okay {
+                ffi::fclose(file);
+                return Err(retcode);
+            }
+
+            ffi::fflush(file);
+            ffi::rewind(file);
+
+            let mut buf = Vec::new();
+            let mut chunk = [0u8; 4096];
+            loop {
+                let n = ffi::fread(
+                    chunk.as_mut_ptr() as *mut std::os::raw::c_void,
+                    1,
+                    chunk.len() as _,
+                    file,
+                );
+                if n == 0 {
+                    break;
+                }
+                buf.extend_from_slice(&chunk[..n as usize]);
+            }
+            ffi::fclose(file);
+
+            Ok(String::from_utf8_lossy(&buf).into_owned())
+        }
+    }
+
+    /// Writes the solving statistics in JSON format directly to `path`
+    /// (`SCIPprintStatisticsJson`), streaming through SCIP's `FILE*` writer
+    /// without buffering the output in memory.
+    pub(crate) fn write_statistics_json(&self, path: &str) -> Result<(), Retcode> {
+        let c_path = CString::new(path).unwrap();
+        unsafe {
+            let file = ffi::fopen(c_path.as_ptr(), c"w".as_ptr());
+            if file.is_null() {
+                return Err(Retcode::FileCreateError);
+            }
+
+            let retcode = Retcode::from(ffi::SCIPprintStatisticsJson(self.raw, file));
+            ffi::fclose(file);
+            if retcode != Retcode::Okay {
+                return Err(retcode);
+            }
+        }
+        Ok(())
+    }
+
     pub(crate) fn vars(&self, original: bool, capture: bool) -> BTreeMap<usize, *mut SCIP_Var> {
         // NOTE: this method should only be called once per SCIP instance
         let n_vars = {


### PR DESCRIPTION
Exposes SCIP 10's JSON statistics output via three methods on `WithSolvingStats`: `stats_json()` returns the statistics as a `String`, `write_stats_json(path)` streams them straight to a file without buffering in memory (matching SCIP's native `SCIPprintStatisticsJson` behaviour), and an optional `serde` feature adds `stats_json_value()` returning a `serde_json::Value` for structured access. The README now also notes that the `bundled` feature ships SCIP 10.0.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)