### PR TITLE
Seal internal model traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["Mohammed Ghannam <ghannam@zib.de>"]
 description = "Rust interface for SCIP"
 license = "Apache-2.0"
 repository = "https://github.com/scipopt/russcip"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2024"
 exclude = ["data/test/*"]
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -46,6 +46,22 @@ pub struct Solving;
 #[derive(Debug)]
 pub struct Solved;
 
+/// Sealing for the crate's model-behavior and stage-marker traits.
+///
+/// These traits exist only to organize `Model<S>`'s methods by lifecycle stage;
+/// they are not extension points. Requiring [`sealed::Sealed`] as a supertrait
+/// prevents downstream crates from implementing them, which in turn lets us add
+/// new methods to them without a breaking change (see cargo-semver-checks'
+/// `trait_method_added` lint).
+mod sealed {
+    /// Marker trait that only types within this crate implement.
+    pub trait Sealed {}
+}
+impl<S> sealed::Sealed for Model<S> {}
+impl sealed::Sealed for ProblemCreated {}
+impl sealed::Sealed for Solving {}
+impl sealed::Sealed for Solved {}
+
 impl Model<Unsolved> {
     /// Creates a new `Model` instance with an `Unsolved` state.
     pub fn new() -> Self {
@@ -861,7 +877,7 @@ impl Model<Solved> {
 }
 
 /// A trait for optimization models with a problem created.
-pub trait ModelWithProblem {
+pub trait ModelWithProblem: sealed::Sealed {
     /// Returns a vector of all variables in the optimization model.
     fn vars(&self) -> Vec<Variable>;
     /// Returns a vector of all original variables in the optimization model.
@@ -911,7 +927,7 @@ pub trait ModelWithProblem {
 }
 
 /// A trait for model stages that have a problem.
-pub trait ModelStageWithProblem {}
+pub trait ModelStageWithProblem: sealed::Sealed {}
 impl ModelStageWithProblem for ProblemCreated {}
 impl ModelStageWithProblem for Solved {}
 impl ModelStageWithProblem for Solving {}
@@ -1027,7 +1043,7 @@ impl<S: ModelStageWithProblem> ModelWithProblem for Model<S> {
 }
 
 /// A trait for optimization models with a problem created or solved.
-pub trait ProblemOrSolving {
+pub trait ProblemOrSolving: sealed::Sealed {
     /// Create a solution in the original space
     fn create_orig_sol(&'_ self) -> Solution<'_>;
 
@@ -1245,7 +1261,7 @@ pub trait ProblemOrSolving {
 }
 
 /// A trait for model stages that have a problem or are during solving.
-pub trait ModelStageProblemOrSolving {}
+pub trait ModelStageProblemOrSolving: sealed::Sealed {}
 impl ModelStageProblemOrSolving for ProblemCreated {}
 impl ModelStageProblemOrSolving for Solving {}
 
@@ -1602,7 +1618,7 @@ impl<S: ModelStageProblemOrSolving> ProblemOrSolving for Model<S> {
 }
 
 /// A trait for optimization models with any state that might have solutions.
-pub trait WithSolutions {
+pub trait WithSolutions: sealed::Sealed {
     /// Returns the best solution for the optimization model, if one exists.
     fn best_sol(&'_ self) -> Option<Solution<'_>>;
 
@@ -1652,7 +1668,7 @@ impl<S: ModelStageWithSolutions> WithSolutions for Model<S> {
 }
 
 /// A trait for optimization models with any state that might have solving statistics.
-pub trait WithSolvingStats {
+pub trait WithSolvingStats: sealed::Sealed {
     /// Returns the objective value of the best solution found by the optimization model.
     fn obj_val(&self) -> f64;
 

--- a/src/param.rs
+++ b/src/param.rs
@@ -1,6 +1,18 @@
 use crate::{Model, Retcode};
 
-pub trait ScipParameter: Sized {
+/// Sealing for [`ScipParameter`], which is implemented only for the fixed set of
+/// primitive types SCIP's C API accepts. Sealing keeps it closed to downstream
+/// implementations so new methods can be added without a breaking change.
+mod sealed {
+    pub trait Sealed {}
+    impl Sealed for f64 {}
+    impl Sealed for i32 {}
+    impl Sealed for i64 {}
+    impl Sealed for bool {}
+    impl Sealed for String {}
+}
+
+pub trait ScipParameter: Sized + sealed::Sealed {
     fn set<T>(model: Model<T>, name: &str, value: Self) -> Result<Model<T>, Retcode>;
     fn get<T>(model: &Model<T>, name: &str) -> Self;
 }


### PR DESCRIPTION
## What

Seals the crate's internal, non-extension traits so new methods can be added to them without a semver-major break.

**Sealed** (implemented only for `Model<S>` / the stage structs — these organize methods by lifecycle stage and are not meant to be implemented downstream):

- `ProblemOrSolving`, `ModelWithProblem`, `WithSolutions`, `WithSolvingStats`
- the public marker traits `ModelStageWithProblem`, `ModelStageProblemOrSolving`
- `ScipParameter` (closed to the fixed set of primitive C param types)

**Left open** — the genuine plugin extension points, which downstream crates are expected to implement: `Heuristic`, `Separator`, `Pricer`, `NodeSel`, `Eventhdlr`, `Conshdlr`, `BranchRule`, `CanBeAddedToModel`.

## Why

`cargo-semver-checks`' `trait_method_added` lint flags adding a method (without a default) to a public non-sealed trait as a breaking change. These traits are internal organization, not extension points, so sealing them both states the intent and lets us add methods freely. Sealing uses a `pub trait Sealed {}` inside a private module (nominally public to avoid the `private_bounds` lint, unreachable externally).

## Testing

`cargo build`, `cargo clippy --all-targets`, and the full test suite all pass.