### PR TITLE
Add expr! and cons! macros for nonlinear constraints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
+[workspace]
+members = ["russcip-macros"]
+
 [package]
 name = "russcip"
 authors = ["Mohammed Ghannam <ghannam@zib.de>"]
@@ -26,6 +29,7 @@ serde = ["dep:serde_json"]
 scip-sys = { version = "0.1.28", default-features = false }
 anymap3 = { version = "1.0.1", optional = true }
 serde_json = { version = "1.0", optional = true }
+russcip-macros = { version = "0.11.0", path = "russcip-macros" }
 
 [dev-dependencies]
 rayon = "1.5.1"

--- a/NONLINEAR.md
+++ b/NONLINEAR.md
@@ -16,6 +16,39 @@ let solved = model.solve();
 assert!((solved.obj_val() - 4.0).abs() < 1e-6);
 ```
 
+## The `cons!` and `expr!` macros
+
+[`cons!`] and [`expr!`] write the same thing as mathematical syntax. Inside them `^` binds
+tighter than `*`, as it does in mathematics — unlike Rust's own `^`, which is bitwise xor and
+binds looser than `+`. A comparison becomes a whole constraint, and a `sum(i in <iter>, <expr>)`
+comprehension makes an aggregate:
+
+```rust
+use russcip::prelude::*;
+
+let mut model = Model::default().maximize().hide_output();
+let x = model.add(var().name("x").obj(1.).cont(0.0..=10.0));
+let y = model.add(var().name("y").cont(0.0..=10.0));
+let n = 4;
+let xs: Vec<_> = (0..n)
+    .map(|i| model.add(var().name(&format!("x{i}")).obj(1.).cont(0.0..=10.0)))
+    .collect();
+
+// x^2 + y^2 <= 16
+model.add(cons!(x ^ 2 + y ^ 2 <= 16));
+// 1 <= x + y <= 5
+model.add(cons!(1 <= x + y <= 5));
+// sum(x_i^2) <= 4
+model.add(cons!(sum(i in 0..n, xs[i] ^ 2) <= 4));
+
+let solved = model.solve();
+assert_eq!(solved.status(), Status::Optimal);
+```
+
+[`expr!`] builds just the expression, so it can be used anywhere an [`Expr`] is expected:
+`let e = expr!(x ^ 2 + 3 * y);`. The macros are re-exported from the crate root and the
+[`prelude`].
+
 ## Building an expression
 
 The leaves are `Expr::var(&v)` for a model variable and `Expr::constant(k)` for a number. From

--- a/README.md
+++ b/README.md
@@ -61,6 +61,31 @@ let solved = model.solve();
 assert_eq!(solved.status(), Status::Optimal);
 ```
 
+[`cons!`] and [`expr!`] write the same thing as mathematical syntax, with `^` binding tighter
+than `*` (unlike Rust's `^`, which is bitwise xor):
+
+```rust
+use russcip::prelude::*;
+
+let mut model = Model::default().maximize().hide_output();
+let x = model.add(var().name("x").obj(1.).cont(0.0..=10.0));
+let y = model.add(var().name("y").cont(0.0..=10.0));
+let n = 4;
+let xs: Vec<_> = (0..n)
+    .map(|i| model.add(var().name(&format!("x{i}")).obj(1.).cont(0.0..=10.0)))
+    .collect();
+
+// x² + y² <= 16
+model.add(cons!(x ^ 2 + y ^ 2 <= 16));
+// 1 <= x + y <= 5
+model.add(cons!(1 <= x + y <= 5));
+// Σ xᵢ² <= 4
+model.add(cons!(sum(i in 0..n, xs[i] ^ 2) <= 4));
+
+let solved = model.solve();
+assert_eq!(solved.status(), Status::Optimal);
+```
+
 Sums and products are n-ary and come from iterators, so a coefficient array and a variable array
 pair up with `zip`:
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,4 +14,4 @@ This directory contains examples of how to use the `russcip` library.
 9. [Depth-first node selection](depth_first_node_selection.rs): An example showing how to implement a custom node selector that traverses the branch-and-bound tree in depth-first order.
 10. [Bin packing](bin_packing.rs): An example branch-and-price implementation for the bin packing problem, following the guide in https://github.com/mmghannam/co-work2024/blob/main/Day3/README.md
 11. [Concurrent solve](concurrent_solve.rs): An example showing how to solve a model using SCIP's concurrent solvers to leverage multiple CPU cores.
-12. [Nonlinear constraints](nonlinear.rs): An example showing how to build nonlinear constraints from `Expr` trees, aggregate sums and products over iterators, and model a nonlinear objective through an auxiliary variable.
+12. [Nonlinear constraints](nonlinear.rs): An example showing how to build nonlinear constraints with the `cons!` macro, aggregate with `sum(...)` comprehensions, and model a nonlinear objective through an auxiliary variable.

--- a/examples/nonlinear.rs
+++ b/examples/nonlinear.rs
@@ -1,5 +1,5 @@
-//! Nonlinear constraints: building `Expr` trees, aggregating over iterators,
-//! and how to handle a nonlinear objective.
+//! Nonlinear constraints: the `cons!` macro, comprehensions, and how to handle
+//! a nonlinear objective.
 //!
 //! Run with `cargo run --example nonlinear`.
 
@@ -16,16 +16,9 @@ fn rosenbrock() {
     let y = model.add(var().name("y").cont(-2.0..=2.0));
     let t = model.add(var().name("t").obj(1.0).cont(0.0..=1e6));
 
-    // `^` is not an operator on `Expr`: Rust's `^` is bitwise xor and binds
-    // looser than `+`, so `a ^ 2 + b` would parse as `a ^ (2 + b)`. Powers use
-    // `Expr::pow` instead.
-    //
-    // Everything else is written with the ordinary arithmetic operators. Both
-    // sides of the comparison go into one body: `f(x,y) <= t` is `f(x,y) - t <= 0`.
-    let body = Expr::pow(1.0 - Expr::var(&x), 2.0)
-        + 100.0 * Expr::pow(Expr::var(&y) - Expr::pow(Expr::var(&x), 2.0), 2.0)
-        - Expr::var(&t);
-    model.add(cons().expression(body).le(0.0).name("rosenbrock"));
+    // Note `^` binds tighter than `*` here, as in mathematics — unlike Rust's
+    // own `^`, which is bitwise xor and binds looser than `+`.
+    model.add(cons!((1 - x) ^ 2 + 100 * (y - x ^ 2) ^ 2 <= t).name("rosenbrock"));
 
     let solved = model.solve();
     let sol = solved.best_sol().unwrap();
@@ -37,8 +30,8 @@ fn rosenbrock() {
     println!();
 }
 
-/// A norm-ball constrained problem, showing aggregates: maximise a weighted sum
-/// subject to `sum(x_i^2) <= r^2`.
+/// A norm-ball constrained problem, showing comprehensions: maximise a weighted
+/// sum subject to `sum(x_i^2) <= r^2`.
 fn ball_constrained() {
     const N: usize = 5;
     let radius: f64 = 3.0;
@@ -50,17 +43,10 @@ fn ball_constrained() {
         .map(|i| model.add(var().name(&format!("x{i}")).cont(0.0..=10.0)))
         .collect();
 
-    // The objective has no nonlinearity but is still easier to read as a sum.
-    // `sum_weighted` takes (coefficient, subexpression) pairs, so a coefficient
-    // array and a variable array pair up with `zip`.
     let obj = model.add(var().name("obj").obj(1.0).cont(0.0..=1e6));
-    let weighted = Expr::sum_weighted(profit.iter().zip(&xs).map(|(c, x)| (*c, Expr::var(x))));
-    model.add(cons().expression(weighted - Expr::var(&obj)).eq(0.0));
+    model.add(cons!(sum(i in 0..N, profit[i] * xs[i]) = obj));
 
-    // sum(x_i^2) <= radius^2. Sums are n-ary, so this is one SCIP sum
-    // expression regardless of how many terms it has.
-    let squares = Expr::sum(xs.iter().map(|x| Expr::pow(Expr::var(x), 2.0)));
-    model.add(cons().expression(squares).le(radius * radius).name("ball"));
+    model.add(cons!(sum(x in &xs, x ^ 2) <= radius * radius).name("ball"));
 
     let solved = model.solve();
     let sol = solved.best_sol().unwrap();
@@ -82,11 +68,7 @@ fn signed_power() {
     let q = model.add(var().name("q").cont(-4.0..=4.0));
 
     // signpower(q, 1.5) == -8  =>  |q|^1.5 = 8 with q negative  =>  q = -4
-    model.add(
-        cons()
-            .expression(Expr::signpower(Expr::var(&q), 1.5))
-            .eq(-8.0),
-    );
+    model.add(cons!(signpower(q, 1.5) = -8));
 
     let solved = model.solve();
     let sol = solved.best_sol().unwrap();

--- a/russcip-macros/Cargo.toml
+++ b/russcip-macros/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "russcip-macros"
+version = "0.11.0"
+authors = ["Mohammed Ghannam <ghannam@zib.de>"]
+description = "Procedural macros for russcip"
+license = "Apache-2.0"
+repository = "https://github.com/scipopt/russcip"
+edition = "2024"
+
+[lib]
+proc-macro = true
+# A proc-macro crate runs at compile time and has no runtime tests of its own —
+# its behaviour is covered from `russcip`. Building a test harness for it makes
+# coverage tooling try to ptrace a compiler plugin, which cargo-tarpaulin cannot
+# do, so skip it.
+test = false
+doctest = false
+
+[dependencies]
+proc-macro2 = "1"
+quote = "1"

--- a/russcip-macros/Cargo.toml
+++ b/russcip-macros/Cargo.toml
@@ -18,4 +18,5 @@ doctest = false
 
 [dependencies]
 proc-macro2 = "1"
+proc-macro-crate = "3"
 quote = "1"

--- a/russcip-macros/src/lib.rs
+++ b/russcip-macros/src/lib.rs
@@ -7,7 +7,34 @@
 
 use proc_macro::TokenStream;
 use proc_macro2::{Delimiter, Group, Spacing, Span, TokenStream as TS2, TokenTree};
+use proc_macro_crate::{FoundCrate, crate_name};
 use quote::{quote, quote_spanned};
+
+/// The path to the `russcip` crate as seen from the crate invoking the macro.
+///
+/// `proc_macro_crate` resolves the real name, so a downstream crate that renames
+/// the dependency (`scip = { package = "russcip", .. }`) still expands to a
+/// resolvable path. When the macro is used inside the `russcip` package it stays
+/// `::russcip` (see the match below), which resolves through
+/// `extern crate self as russcip;` in the library and through the dependency in
+/// doctests and examples.
+fn russcip_path() -> TS2 {
+    match crate_name("russcip") {
+        // `Itself` is returned for every compilation unit that belongs to the
+        // `russcip` package — the library, its unit tests, its doctests and its
+        // examples. `crate` is only correct for the first two, so always use
+        // `::russcip`, which resolves inside the library via
+        // `extern crate self as russcip;` and in doctests/examples through the
+        // dependency.
+        Ok(FoundCrate::Itself) | Err(_) => quote!(::russcip),
+        // A downstream crate may rename the dependency (`scip = { package =
+        // "russcip", .. }`); resolve the real name so the path still works.
+        Ok(FoundCrate::Name(name)) => {
+            let ident = proc_macro2::Ident::new(&name, Span::call_site());
+            quote!(::#ident)
+        }
+    }
+}
 
 /// Unary functions SCIP has an expression handler for.
 ///
@@ -24,9 +51,30 @@ enum Cmp {
     Eq,
 }
 
+/// Parses a Rust numeric literal as an `f64`.
+///
+/// `Literal::to_string()` keeps the source spelling, so it can carry separators
+/// and a type suffix: `1_000`, `2.0_f64`, `1.5e3f32`. `parse::<f64>()` rejects
+/// all of those, so strip the underscores and any trailing type suffix (the
+/// trailing run of alphabetic characters — exponent digits stop the scan, so
+/// `1.5e3f64` leaves `1.5e3`) before parsing.
+fn parse_number(s: &str) -> Option<f64> {
+    let s = s.replace('_', "");
+    if let Ok(v) = s.parse::<f64>() {
+        return Some(v);
+    }
+    let end = s
+        .bytes()
+        .rposition(|b| !b.is_ascii_alphabetic())
+        .map(|i| i + 1)
+        .unwrap_or(0);
+    s[..end].parse::<f64>().ok()
+}
+
 struct Parser {
     toks: Vec<TokenTree>,
     pos: usize,
+    crate_path: TS2,
 }
 
 impl Parser {
@@ -34,6 +82,7 @@ impl Parser {
         Parser {
             toks: ts.into_iter().collect(),
             pos: 0,
+            crate_path: russcip_path(),
         }
     }
 
@@ -168,7 +217,8 @@ impl Parser {
         let base = self.atom()?;
         if self.eat('^') {
             let (v, span) = self.signed_number()?;
-            return Ok(quote_spanned! { span => ::russcip::Expr::pow(#base, #v) });
+            let cp = &self.crate_path;
+            return Ok(quote_spanned! { span => #cp::Expr::pow(#base, #v) });
         }
         Ok(base)
     }
@@ -204,9 +254,9 @@ impl Parser {
             Some(TokenTree::Literal(lit)) => {
                 self.pos += 1;
                 let s = lit.to_string();
-                match s.parse::<f64>() {
-                    Ok(v) => Ok((v, lit.span())),
-                    Err(_) => Err((lit.span(), format!("`{s}` is not a numeric literal"))),
+                match parse_number(&s) {
+                    Some(v) => Ok((v, lit.span())),
+                    None => Err((lit.span(), format!("`{s}` is not a numeric literal"))),
                 }
             }
             Some(other) => Err((
@@ -236,7 +286,8 @@ impl Parser {
             TokenTree::Group(g) if g.delimiter() == Delimiter::Brace => {
                 self.pos += 1;
                 let inner = g.stream();
-                Ok(quote_spanned! { g.span() => ::russcip::Expr::of(#inner) })
+                let cp = &self.crate_path;
+                Ok(quote_spanned! { g.span() => #cp::Expr::of(#inner) })
             }
 
             TokenTree::Group(g) if g.delimiter() == Delimiter::Parenthesis => {
@@ -280,8 +331,9 @@ impl Parser {
                         }
                         let (v, _) = inner.signed_number()?;
                         inner.finish()?;
+                        let cp = &self.crate_path;
                         return Ok(
-                            quote_spanned! { id.span() => ::russcip::Expr::signpower(#arg, #v) },
+                            quote_spanned! { id.span() => #cp::Expr::signpower(#arg, #v) },
                         );
                     }
 
@@ -300,7 +352,8 @@ impl Parser {
                     let arg = inner.expr()?;
                     inner.finish()?;
                     let f = proc_macro2::Ident::new(&name, id.span());
-                    return Ok(quote_spanned! { id.span() => ::russcip::Expr::#f(#arg) });
+                    let cp = &self.crate_path;
+                    return Ok(quote_spanned! { id.span() => #cp::Expr::#f(#arg) });
                 }
 
                 // A bare identifier, possibly indexed (`x`, `x[i]`, `g[i][j]`),
@@ -308,15 +361,17 @@ impl Parser {
                 // `Variable` becomes a variable term and an `f64` a constant —
                 // which is what lets `c[i] * x[i]` work without annotation.
                 let place = self.place(&id);
-                Ok(quote_spanned! { id.span() => ::russcip::AsExpr::as_expr(&#place) })
+                let cp = &self.crate_path;
+                Ok(quote_spanned! { id.span() => #cp::AsExpr::as_expr(&#place) })
             }
 
             TokenTree::Literal(lit) => {
                 self.pos += 1;
                 let s = lit.to_string();
-                match s.parse::<f64>() {
-                    Ok(v) => Ok(quote_spanned! { lit.span() => ::russcip::Expr::constant(#v) }),
-                    Err(_) => Err((lit.span(), format!("`{s}` is not a numeric literal"))),
+                let cp = &self.crate_path;
+                match parse_number(&s) {
+                    Some(v) => Ok(quote_spanned! { lit.span() => #cp::Expr::constant(#v) }),
+                    None => Err((lit.span(), format!("`{s}` is not a numeric literal"))),
                 }
             }
 
@@ -379,9 +434,10 @@ impl Parser {
         inner.finish()?;
 
         let ctor = proc_macro2::Ident::new(if kind == "sum" { "sum" } else { "product" }, span);
+        let cp = &self.crate_path;
 
         Ok(quote_spanned! { span =>
-            ::russcip::Expr::#ctor(
+            #cp::Expr::#ctor(
                 ::core::iter::IntoIterator::into_iter(#iterable).map(|#pattern| #body)
             )
         })
@@ -421,7 +477,8 @@ fn parse_constraint(ts: TS2) -> Result<TS2, PErr> {
         Cmp::Ge => quote! { .ge(0.0) },
         Cmp::Eq => quote! { .eq(0.0) },
     };
-    Ok(quote! { ::russcip::builder::cons::cons().expression(#diff) #bounded })
+    let cp = &p.crate_path;
+    Ok(quote! { #cp::builder::cons::cons().expression(#diff) #bounded })
 }
 
 /// Speculatively parses `lit <= expr <= lit` (or `>=`), rewinding if the input
@@ -481,8 +538,9 @@ fn try_chained(p: &mut Parser) -> Result<Option<TS2>, PErr> {
     } else {
         (hi, lo)
     };
+    let cp = &p.crate_path;
     Ok(Some(
-        quote! { ::russcip::builder::cons::cons().expression(#ex).bounds(#lhs, #rhs) },
+        quote! { #cp::builder::cons::cons().expression(#ex).bounds(#lhs, #rhs) },
     ))
 }
 
@@ -494,9 +552,13 @@ fn try_chained(p: &mut Parser) -> Result<Option<TS2>, PErr> {
 /// constant, so `c[i] * x[i]` needs no annotation.
 ///
 /// Operator precedence is mathematical, **not** Rust's: `^` binds tighter than
-/// `*` and is right-associative, so `x^2 + 3*y` means `(x^2) + (3*y)`. This is
-/// why the macro parses the raw token stream instead of a `syn::ScipExpr` — Rust
-/// itself parses `^` as `BitXor`, which binds looser than both `+` and `*`.
+/// `*`, so `x^2 + 3*y` means `(x^2) + (3*y)`. This is why the macro parses the
+/// raw token stream instead of a `syn::ScipExpr` — Rust itself parses `^` as
+/// `BitXor`, which binds looser than both `+` and `*`.
+///
+/// The exponent must be a numeric literal and `^` is **not** chainable: SCIP's
+/// `SCIPcreateExprPow` takes a `SCIP_Real` exponent, so `x ^ 2 ^ 3` has no
+/// meaning. Write `x ^ 8` instead.
 ///
 /// ```ignore
 /// expr!(x^2 + 3*y - exp(x))

--- a/russcip-macros/src/lib.rs
+++ b/russcip-macros/src/lib.rs
@@ -1,0 +1,548 @@
+//! Procedural macros for [`russcip`](https://docs.rs/russcip).
+//!
+//! [`expr!`] builds an expression, [`cons!`] builds a whole constraint from a
+//! comparison. Both share one recursive-descent parser over the raw token
+//! stream — `syn::ScipExpr` is unusable here because Rust parses `^` as `BitXor`,
+//! which binds looser than `+` and `*`.
+
+use proc_macro::TokenStream;
+use proc_macro2::{Delimiter, Group, Spacing, Span, TokenStream as TS2, TokenTree};
+use quote::{quote, quote_spanned};
+
+/// Unary functions SCIP has an expression handler for.
+///
+/// `sqrt` is deliberately absent: SCIP has no `sqrt` handler, and `x^0.5` is
+/// the supported spelling. The error message says so.
+const FUNCS: &[&str] = &["exp", "log", "sin", "cos", "abs", "entropy"];
+
+type PErr = (Span, String);
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Cmp {
+    Le,
+    Ge,
+    Eq,
+}
+
+struct Parser {
+    toks: Vec<TokenTree>,
+    pos: usize,
+}
+
+impl Parser {
+    fn new(ts: TS2) -> Self {
+        Parser {
+            toks: ts.into_iter().collect(),
+            pos: 0,
+        }
+    }
+
+    fn peek(&self) -> Option<&TokenTree> {
+        self.toks.get(self.pos)
+    }
+
+    fn peek_at(&self, off: usize) -> Option<&TokenTree> {
+        self.toks.get(self.pos + off)
+    }
+
+    fn span_here(&self) -> Span {
+        self.peek()
+            .map(|t| t.span())
+            .unwrap_or_else(Span::call_site)
+    }
+
+    /// Consumes a single-character operator. The expression grammar has no
+    /// multi-character operators, and every comparison operator starts with a
+    /// character this never matches, so a plain character test is enough.
+    fn eat(&mut self, c: char) -> bool {
+        if let Some(TokenTree::Punct(p)) = self.peek()
+            && p.as_char() == c
+        {
+            self.pos += 1;
+            return true;
+        }
+        false
+    }
+
+    /// Consumes a comparison operator: `<=`, `>=`, `==` or `=`.
+    ///
+    /// `<=` arrives as `Punct('<', Joint)` followed by `Punct('=')`, whereas a
+    /// bare `<` is `Punct('<', Alone)`, so the two are distinguishable.
+    fn eat_cmp(&mut self) -> Option<(Cmp, Span)> {
+        let (c, spacing, span) = match self.peek() {
+            Some(TokenTree::Punct(p)) => (p.as_char(), p.spacing(), p.span()),
+            _ => return None,
+        };
+        let then_eq = matches!(self.peek_at(1), Some(TokenTree::Punct(p)) if p.as_char() == '=');
+
+        match c {
+            '<' | '>' if spacing == Spacing::Joint && then_eq => {
+                self.pos += 2;
+                Some((if c == '<' { Cmp::Le } else { Cmp::Ge }, span))
+            }
+            '=' if spacing == Spacing::Joint && then_eq => {
+                self.pos += 2;
+                Some((Cmp::Eq, span))
+            }
+            '=' if spacing != Spacing::Joint => {
+                self.pos += 1;
+                Some((Cmp::Eq, span))
+            }
+            _ => None,
+        }
+    }
+
+    /// The error to report where a comparison was expected but not found.
+    fn cmp_error(&self) -> PErr {
+        match self.peek() {
+            Some(TokenTree::Punct(p)) if p.as_char() == '<' || p.as_char() == '>' => (
+                p.span(),
+                format!(
+                    "`{0}` is not representable — a constraint has closed bounds; use `{0}=`",
+                    p.as_char()
+                ),
+            ),
+            Some(t) => (
+                t.span(),
+                format!("expected a comparison (`<=`, `>=`, `=`), found `{t}`"),
+            ),
+            None => (
+                Span::call_site(),
+                "expected a comparison (`<=`, `>=`, `=`)".to_string(),
+            ),
+        }
+    }
+
+    /// `expr := term (('+' | '-') term)*`
+    fn expr(&mut self) -> Result<TS2, PErr> {
+        let mut lhs = self.term()?;
+        loop {
+            if self.eat('+') {
+                let r = self.term()?;
+                lhs = quote! { ::core::ops::Add::add(#lhs, #r) };
+            } else if self.eat('-') {
+                let r = self.term()?;
+                lhs = quote! { ::core::ops::Sub::sub(#lhs, #r) };
+            } else {
+                return Ok(lhs);
+            }
+        }
+    }
+
+    /// `term := unary (('*' | '/') unary)*`
+    fn term(&mut self) -> Result<TS2, PErr> {
+        let mut lhs = self.unary()?;
+        loop {
+            if self.eat('*') {
+                let r = self.unary()?;
+                lhs = quote! { ::core::ops::Mul::mul(#lhs, #r) };
+            } else if self.eat('/') {
+                let r = self.unary()?;
+                lhs = quote! { ::core::ops::Div::div(#lhs, #r) };
+            } else {
+                return Ok(lhs);
+            }
+        }
+    }
+
+    /// `unary := ('-' | '+')* power`
+    fn unary(&mut self) -> Result<TS2, PErr> {
+        if self.eat('-') {
+            let e = self.unary()?;
+            return Ok(quote! { ::core::ops::Neg::neg(#e) });
+        }
+        if self.eat('+') {
+            return self.unary();
+        }
+        self.power()
+    }
+
+    /// `power := atom ('^' signed-number)?`
+    ///
+    /// The exponent must be a numeric literal. That is not a shortcut: SCIP's
+    /// own grammar is `Factor -> Base [ "^" number ]`, and `SCIPcreateExprPow`
+    /// takes a `SCIP_Real` exponent, so a variable exponent was never
+    /// representable. Rejecting it here turns it into a compile error rather
+    /// than a confusing runtime failure.
+    fn power(&mut self) -> Result<TS2, PErr> {
+        let base = self.atom()?;
+        if self.eat('^') {
+            let (v, span) = self.signed_number()?;
+            return Ok(quote_spanned! { span => ::russcip::Expr::pow(#base, #v) });
+        }
+        Ok(base)
+    }
+
+    /// An optionally signed numeric literal. `-` and the literal are separate
+    /// tokens in a `TokenStream`, so the sign has to be taken here.
+    fn signed_number(&mut self) -> Result<(f64, Span), PErr> {
+        let neg = if self.eat('-') {
+            true
+        } else {
+            self.eat('+');
+            false
+        };
+        let (v, span) = self.number()?;
+        Ok((if neg { -v } else { v }, span))
+    }
+
+    /// Like [`Parser::signed_number`] but speculative: on anything that is not
+    /// a signed literal it rewinds and yields `None`.
+    fn try_signed_number(&mut self) -> Option<(f64, Span)> {
+        let save = self.pos;
+        match self.signed_number() {
+            Ok(v) => Some(v),
+            Err(_) => {
+                self.pos = save;
+                None
+            }
+        }
+    }
+
+    fn number(&mut self) -> Result<(f64, Span), PErr> {
+        match self.peek().cloned() {
+            Some(TokenTree::Literal(lit)) => {
+                self.pos += 1;
+                let s = lit.to_string();
+                match s.parse::<f64>() {
+                    Ok(v) => Ok((v, lit.span())),
+                    Err(_) => Err((lit.span(), format!("`{s}` is not a numeric literal"))),
+                }
+            }
+            Some(other) => Err((
+                other.span(),
+                format!("expected a numeric literal, found `{other}` — SCIP takes a constant here"),
+            )),
+            None => Err((Span::call_site(), "expected a numeric literal".to_string())),
+        }
+    }
+
+    /// `atom := number | place | call | comprehension | '(' expr ')' | '{' rust '}'`
+    fn atom(&mut self) -> Result<TS2, PErr> {
+        let tt = match self.peek().cloned() {
+            Some(t) => t,
+            None => {
+                return Err((
+                    Span::call_site(),
+                    "unexpected end of expression".to_string(),
+                ));
+            }
+        };
+
+        match tt {
+            // `{ rust_expr }` splices in any value that is `Into<Expr>` — the way
+            // to use a value built in Rust inside an otherwise literal
+            // expression.
+            TokenTree::Group(g) if g.delimiter() == Delimiter::Brace => {
+                self.pos += 1;
+                let inner = g.stream();
+                Ok(quote_spanned! { g.span() => ::russcip::Expr::of(#inner) })
+            }
+
+            TokenTree::Group(g) if g.delimiter() == Delimiter::Parenthesis => {
+                self.pos += 1;
+                let mut inner = Parser::new(g.stream());
+                let e = inner.expr()?;
+                inner.finish()?;
+                Ok(e)
+            }
+
+            TokenTree::Ident(id) => {
+                self.pos += 1;
+                let name = id.to_string();
+
+                let call_group = match self.peek() {
+                    Some(TokenTree::Group(g)) if g.delimiter() == Delimiter::Parenthesis => {
+                        Some(g.clone())
+                    }
+                    _ => None,
+                };
+
+                if let Some(g) = call_group {
+                    self.pos += 1;
+
+                    if name == "sum" || name == "prod" {
+                        return self.comprehension(&name, &g, id.span());
+                    }
+
+                    // `signpower(x, n)` = sign(x)|x|^n. Unlike the others it
+                    // takes an exponent as well as a child, mirroring
+                    // `SCIPcreateExprSignpower`.
+                    if name == "signpower" {
+                        let mut inner = Parser::new(g.stream());
+                        let arg = inner.expr()?;
+                        if !inner.eat(',') {
+                            return Err((
+                                id.span(),
+                                "signpower takes two arguments: `signpower(expr, exponent)`"
+                                    .to_string(),
+                            ));
+                        }
+                        let (v, _) = inner.signed_number()?;
+                        inner.finish()?;
+                        return Ok(
+                            quote_spanned! { id.span() => ::russcip::Expr::signpower(#arg, #v) },
+                        );
+                    }
+
+                    if !FUNCS.contains(&name.as_str()) {
+                        let hint = if name == "sqrt" {
+                            " — SCIP has no `sqrt` handler; write `x^0.5` instead".to_string()
+                        } else {
+                            format!(
+                                " — supported: {}, signpower(expr, n), sum(..), prod(..)",
+                                FUNCS.join(", ")
+                            )
+                        };
+                        return Err((id.span(), format!("unknown function `{name}`{hint}")));
+                    }
+                    let mut inner = Parser::new(g.stream());
+                    let arg = inner.expr()?;
+                    inner.finish()?;
+                    let f = proc_macro2::Ident::new(&name, id.span());
+                    return Ok(quote_spanned! { id.span() => ::russcip::Expr::#f(#arg) });
+                }
+
+                // A bare identifier, possibly indexed (`x`, `x[i]`, `g[i][j]`),
+                // names a value in scope. `AsExpr` resolves it by type, so a
+                // `Variable` becomes a variable term and an `f64` a constant —
+                // which is what lets `c[i] * x[i]` work without annotation.
+                let place = self.place(&id);
+                Ok(quote_spanned! { id.span() => ::russcip::AsExpr::as_expr(&#place) })
+            }
+
+            TokenTree::Literal(lit) => {
+                self.pos += 1;
+                let s = lit.to_string();
+                match s.parse::<f64>() {
+                    Ok(v) => Ok(quote_spanned! { lit.span() => ::russcip::Expr::constant(#v) }),
+                    Err(_) => Err((lit.span(), format!("`{s}` is not a numeric literal"))),
+                }
+            }
+
+            other => Err((other.span(), format!("unexpected token `{other}`"))),
+        }
+    }
+
+    /// An identifier followed by any number of `[...]` index groups, re-emitted
+    /// as the Rust place expression it is.
+    fn place(&mut self, id: &proc_macro2::Ident) -> TS2 {
+        let mut out = quote! { #id };
+        while let Some(TokenTree::Group(g)) = self.peek() {
+            if g.delimiter() != Delimiter::Bracket {
+                break;
+            }
+            let g = g.clone();
+            self.pos += 1;
+            out = quote! { #out #g };
+        }
+        out
+    }
+
+    /// `sum(pattern in iterable, expression)`, and `prod` likewise.
+    ///
+    /// Expands to `Expr::sum(IntoIterator::into_iter(iterable).map(|pattern| expression))`.
+    fn comprehension(&mut self, kind: &str, g: &Group, span: Span) -> Result<TS2, PErr> {
+        let toks: Vec<TokenTree> = g.stream().into_iter().collect();
+        let usage =
+            format!("`{kind}` takes a comprehension: `{kind}(pattern in iterable, expression)`");
+
+        // Nested groups are single token trees, so a match at this level is
+        // genuinely top-level: `zip(a, b)` hides its comma, and a tuple pattern
+        // `(i, x)` hides its own.
+        let in_pos = toks
+            .iter()
+            .position(|t| matches!(t, TokenTree::Ident(i) if *i == "in"));
+        let in_pos = match in_pos {
+            Some(p) if p > 0 => p,
+            _ => return Err((span, usage)),
+        };
+
+        let comma = match toks[in_pos + 1..]
+            .iter()
+            .position(|t| matches!(t, TokenTree::Punct(p) if p.as_char() == ','))
+        {
+            Some(c) => in_pos + 1 + c,
+            None => return Err((span, usage)),
+        };
+
+        let pattern: TS2 = toks[..in_pos].iter().cloned().collect();
+        let iterable: TS2 = toks[in_pos + 1..comma].iter().cloned().collect();
+        let body_toks: TS2 = toks[comma + 1..].iter().cloned().collect();
+
+        if iterable.is_empty() || body_toks.is_empty() {
+            return Err((span, usage));
+        }
+
+        let mut inner = Parser::new(body_toks);
+        let body = inner.expr()?;
+        inner.finish()?;
+
+        let ctor = proc_macro2::Ident::new(if kind == "sum" { "sum" } else { "product" }, span);
+
+        Ok(quote_spanned! { span =>
+            ::russcip::Expr::#ctor(
+                ::core::iter::IntoIterator::into_iter(#iterable).map(|#pattern| #body)
+            )
+        })
+    }
+
+    fn finish(&mut self) -> Result<(), PErr> {
+        match self.peek() {
+            None => Ok(()),
+            Some(t) => Err((t.span(), format!("unexpected trailing token `{t}`"))),
+        }
+    }
+}
+
+/// Parses a whole constraint: either `expr CMP expr` or `lit CMP expr CMP lit`.
+fn parse_constraint(ts: TS2) -> Result<TS2, PErr> {
+    let mut p = Parser::new(ts);
+
+    if let Some(chained) = try_chained(&mut p)? {
+        return Ok(chained);
+    }
+
+    let lhs = p.expr()?;
+    let cmp = match p.eat_cmp() {
+        Some((c, _)) => c,
+        None => return Err(p.cmp_error()),
+    };
+    let rhs = p.expr()?;
+    p.finish()?;
+
+    // SCIP constraints are `lhs <= expression <= rhs` with constant bounds, so
+    // an expression on both sides moves to one: `A <= B` becomes `A - B <= 0`.
+    // Any constant inside is folded back out into the bound when the constraint
+    // is added.
+    let diff = quote! { ::core::ops::Sub::sub(#lhs, #rhs) };
+    let bounded = match cmp {
+        Cmp::Le => quote! { .le(0.0) },
+        Cmp::Ge => quote! { .ge(0.0) },
+        Cmp::Eq => quote! { .eq(0.0) },
+    };
+    Ok(quote! { ::russcip::builder::cons::cons().expression(#diff) #bounded })
+}
+
+/// Speculatively parses `lit <= expr <= lit` (or `>=`), rewinding if the input
+/// is not of that shape. This is the two-sided form, which plain Rust cannot
+/// express because it forbids chained comparison.
+fn try_chained(p: &mut Parser) -> Result<Option<TS2>, PErr> {
+    let save = p.pos;
+
+    let lo = match p.try_signed_number() {
+        Some((v, _)) => v,
+        None => return Ok(None),
+    };
+    let first = match p.eat_cmp() {
+        Some((c, _)) if c != Cmp::Eq => c,
+        _ => {
+            p.pos = save;
+            return Ok(None);
+        }
+    };
+    let ex = match p.expr() {
+        Ok(e) => e,
+        Err(_) => {
+            p.pos = save;
+            return Ok(None);
+        }
+    };
+    let second = match p.eat_cmp() {
+        Some((c, span)) => {
+            if c != first {
+                return Err((
+                    span,
+                    "the two comparisons in a two-sided constraint must point the same way"
+                        .to_string(),
+                ));
+            }
+            c
+        }
+        None => {
+            // Just `lit <= expr`; let the ordinary path handle it.
+            p.pos = save;
+            return Ok(None);
+        }
+    };
+    let hi = match p.try_signed_number() {
+        Some((v, _)) => v,
+        None => {
+            return Err((
+                p.span_here(),
+                "the outer bounds of a two-sided constraint must be numeric literals".to_string(),
+            ));
+        }
+    };
+    p.finish()?;
+
+    let (lhs, rhs) = if second == Cmp::Le {
+        (lo, hi)
+    } else {
+        (hi, lo)
+    };
+    Ok(Some(
+        quote! { ::russcip::builder::cons::cons().expression(#ex).bounds(#lhs, #rhs) },
+    ))
+}
+
+/// Builds an [`Expr`](../russcip/enum.Expr.html) expression tree from mathematical syntax.
+///
+/// Identifiers refer to values in scope and are auto-referenced, so callers
+/// write `x`, not `&x`, and nothing is moved. Indexing works, and the type
+/// decides the meaning: a `Variable` becomes a variable term, an `f64` a
+/// constant, so `c[i] * x[i]` needs no annotation.
+///
+/// Operator precedence is mathematical, **not** Rust's: `^` binds tighter than
+/// `*` and is right-associative, so `x^2 + 3*y` means `(x^2) + (3*y)`. This is
+/// why the macro parses the raw token stream instead of a `syn::ScipExpr` — Rust
+/// itself parses `^` as `BitXor`, which binds looser than both `+` and `*`.
+///
+/// ```ignore
+/// expr!(x^2 + 3*y - exp(x))
+/// expr!(sum(i in 0..n, c[i] * x[i]))
+/// expr!(prod(x in &xs, x))
+/// expr!({ precomputed } + y^2)
+/// ```
+#[proc_macro]
+pub fn expr(input: TokenStream) -> TokenStream {
+    let ts: TS2 = input.into();
+    if ts.is_empty() {
+        return quote! { compile_error!("expr! requires a non-empty expression") }.into();
+    }
+
+    let mut p = Parser::new(ts);
+    let built = p.expr().and_then(|e| p.finish().map(|_| e));
+
+    match built {
+        Ok(e) => e.into(),
+        Err((span, msg)) => quote_spanned! { span => compile_error!(#msg) }.into(),
+    }
+}
+
+/// Builds a constraint from a comparison, ready to pass to `Model::add`.
+///
+/// Accepts `<=`, `>=`, `=` and `==`; strict `<` and `>` are rejected, since a
+/// constraint has closed bounds. Either side may be an expression. The
+/// two-sided form maps directly onto SCIP's `lhs <= expression <= rhs` and is
+/// not expressible in plain Rust, which forbids chained comparison.
+///
+/// ```ignore
+/// model.add(cons!(x^2 + y^2 <= 4));
+/// model.add(cons!(1 <= x + y <= 5).name("band"));
+/// model.add(cons!(x * y = 1));
+/// model.add(cons!(sum(i in 0..n, c[i] * x[i]) <= 10));
+/// ```
+#[proc_macro]
+pub fn cons(input: TokenStream) -> TokenStream {
+    let ts: TS2 = input.into();
+    if ts.is_empty() {
+        return quote! { compile_error!("cons! requires a comparison, e.g. `cons!(x^2 <= 16)`") }
+            .into();
+    }
+
+    match parse_constraint(ts) {
+        Ok(e) => e.into(),
+        Err((span, msg)) => quote_spanned! { span => compile_error!(#msg) }.into(),
+    }
+}

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -20,6 +20,22 @@ use std::fmt;
 /// variable names and by names containing characters the string syntax cannot
 /// express (such as `>`).
 ///
+/// The [`expr!`](macro@crate::expr) and [`cons!`](macro@crate::cons) macros build
+/// an `Expr` (and a whole constraint) from mathematical syntax, with `^` binding
+/// tighter than `*`:
+///
+/// ```
+/// use russcip::prelude::*;
+///
+/// let mut model = Model::default().maximize().hide_output();
+/// let x = model.add(var().name("x").obj(1.).cont(0.0..=10.0));
+///
+/// model.add(cons!(x ^ 2 <= 16));
+///
+/// let solved = model.solve();
+/// assert!((solved.obj_val() - 4.0).abs() < 1e-6);
+/// ```
+///
 /// Expressions are built from [`Expr::var`] and [`Expr::constant`] with the
 /// arithmetic operators and the named constructors ([`Expr::pow`],
 /// [`Expr::exp`], …):
@@ -1103,6 +1119,57 @@ mod tests {
             "got {}",
             solved.obj_val()
         );
+    }
+
+    /// `expr!` builds an `Expr` with `^` binding tighter than `*`, matching
+    /// mathematical convention rather than Rust's bitwise `^`.
+    #[test]
+    fn expr_macro_renders() {
+        let mut model = Model::default().hide_output();
+        let x = model.add(var().name("x").cont(0.0..=10.0));
+        let y = model.add(var().name("y").cont(0.0..=10.0));
+
+        assert_eq!(expr!(x ^ 2 + 3 * y).to_string(), "((<x>^2) + (3 * <y>))");
+        assert_eq!(expr!(x ^ 2 + y ^ 2).to_string(), "((<x>^2) + (<y>^2))");
+    }
+
+    /// The `cons!` macro is sugar for `cons().expression(body).cmp(..)`, so the
+    /// resulting constraint solves the same way as the builder API.
+    #[test]
+    fn cons_macro_simple() {
+        let mut model = Model::default().maximize().hide_output();
+        let x = model.add(var().name("x").obj(1.).cont(0.0..=10.0));
+        model.add(cons!(x ^ 2 <= 16));
+        let solved = model.solve();
+        assert_eq!(solved.status(), Status::Optimal);
+        assert!((solved.obj_val() - 4.0).abs() < 1e-6, "got {}", solved.obj_val());
+    }
+
+    #[test]
+    fn cons_macro_two_sided() {
+        let mut model = Model::default().minimize().hide_output();
+        let x = model.add(var().name("x").obj(1.).cont(0.0..=10.0));
+        let y = model.add(var().name("y").obj(1.).cont(0.0..=10.0));
+        model.add(cons!(1 <= x + y <= 5));
+        let solved = model.solve();
+        assert_eq!(solved.status(), Status::Optimal);
+        assert!((solved.obj_val() - 1.0).abs() < 1e-6, "got {}", solved.obj_val());
+    }
+
+    /// A comprehension sums over an iterator, so `cons!` can aggregate the same
+    /// way the builder's `Expr::sum` does.
+    #[test]
+    fn cons_macro_comprehension() {
+        let mut model = Model::default().maximize().hide_output();
+        let xs: Vec<_> = (0..4)
+            .map(|i| model.add(var().name(&format!("x{i}")).obj(1.).cont(0.0..=10.0)))
+            .collect();
+        model.add(cons!(sum(x in &xs, x ^ 2) <= 16));
+        let solved = model.solve();
+        assert_eq!(solved.status(), Status::Optimal);
+        // Maximising sum(x_i) over the ball sum(x_i^2) <= 16 puts every x_i on
+        // the boundary along (1,1,1,1): x_i = 4/2 = 2, so the objective is 8.
+        assert!((solved.obj_val() - 8.0).abs() < 1e-4, "got {}", solved.obj_val());
     }
 
     /// A mixed-integer nonlinear problem: a binary variable gates a nonlinear

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1176,6 +1176,30 @@ mod tests {
     /// constraint on a continuous variable, and both the integer decision and
     /// the objective are checked.
     #[test]
+    fn cons_macro_mixed_integer() {
+        let mut model = Model::default().minimize().hide_output();
+        let x = model.add(var().name("x").cont(0.0..=10.0));
+        let b = model.add(var().name("b").bin());
+        let t = model.add(var().name("t").obj(1.).cont(0.0..=1e6));
+
+        // Objective lifting: minimise t subject to t >= x^2. A binary gate
+        // `x <= 10*b` and a lower bound `x >= 2` force b=1, and the nonlinear
+        // constraint then pins t to the smallest x^2 = 4.
+        model.add(cons!(x ^ 2 <= t));
+        model.add(cons!(x <= 10 * b));
+        model.add(cons!(x >= 2));
+
+        let solved = model.solve();
+        assert_eq!(solved.status(), Status::Optimal);
+        let sol = solved.best_sol().unwrap();
+        assert_eq!(sol.val(&b), 1.0);
+        assert!((solved.obj_val() - 4.0).abs() < 1e-4, "got {}", solved.obj_val());
+    }
+
+    /// A mixed-integer nonlinear problem: a binary variable gates a nonlinear
+    /// constraint on a continuous variable, and both the integer decision and
+    /// the objective are checked.
+    #[test]
     fn mixed_integer_nonlinear() {
         let mut model = Model::default().maximize().hide_output();
         let x = model.add(var().name("x").obj(1.).cont(0.0..=10.0));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,32 @@
 //! assert_eq!(solved.status(), Status::Optimal);
 //! ```
 //!
+//! The [`cons!`] and [`expr!`] macros write the same thing as mathematical
+//! syntax, with `^` binding tighter than `*` (unlike Rust's `^`, which is
+//! bitwise xor). A comprehension makes an aggregate over an iterator:
+//!
+//! ```rust
+//! use russcip::prelude::*;
+//!
+//! let mut model = Model::default().maximize().hide_output();
+//! let x = model.add(var().name("x").obj(1.).cont(0.0..=10.0));
+//! let y = model.add(var().name("y").cont(0.0..=10.0));
+//! let n = 4;
+//! let xs: Vec<_> = (0..n)
+//!     .map(|i| model.add(var().name(&format!("x{i}")).obj(1.).cont(0.0..=10.0)))
+//!     .collect();
+//!
+//! // x² + y² <= 16
+//! model.add(cons!(x ^ 2 + y ^ 2 <= 16));
+//! // 1 <= x + y <= 5
+//! model.add(cons!(1 <= x + y <= 5));
+//! // Σ xᵢ² <= 4
+//! model.add(cons!(sum(i in 0..n, xs[i] ^ 2) <= 4));
+//!
+//! let solved = model.solve();
+//! assert_eq!(solved.status(), Status::Optimal);
+//! ```
+//!
 //! Aggregates come from iterators, so a coefficient array and a variable array
 //! pair up with `zip`:
 //!
@@ -77,6 +103,9 @@ extern crate core;
 /// Re-exports the `scip_sys` crate, which provides low-level bindings to the SCIP library.
 pub use scip_sys as ffi;
 
+// Lets the `expr!` macro's `::russcip::…` paths resolve inside this crate too.
+extern crate self as russcip;
+
 /// Contains the `BranchRule` trait used to define custom branching rules.
 pub mod branchrule;
 pub use branchrule::*;
@@ -93,6 +122,14 @@ pub use expr::*;
 /// Contains the `ScipExpr` struct, a handle on a `SCIP_EXPR` built by SCIP.
 pub mod scip_expr;
 pub use scip_expr::*;
+
+/// Builds an [`Expr`] expression tree from mathematical syntax, with `^` binding
+/// tighter than `*` (unlike Rust's `^`, which is `BitXor`).
+pub use russcip_macros::expr;
+
+/// Builds a constraint from a comparison (`<=`, `>=`, `=`), ready for
+/// [`Model::add`].
+pub use russcip_macros::cons;
 
 /// The main module, it contains the `Model` struct, which represents an optimization problem.
 pub mod model;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -27,3 +27,4 @@ pub use crate::scip_expr::ScipExpr;
 pub use crate::separator::*;
 pub use crate::status::Status;
 pub use crate::variable::VarType;
+pub use russcip_macros::{cons, expr};


### PR DESCRIPTION
Builds on #292. Adds an `Ex` expression tree plus `expr!`/`cons!` proc-macros, so
constraints can be written as `cons!(x^2 + y^2 <= 16)`, `cons!(1 <= x + y <= 5)` or
`cons!(sum(i in 0..n, c[i] * x[i]) <= 10)`.